### PR TITLE
fix: update build.yaml to use correct syntax for environment variables

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -50,10 +50,10 @@ jobs:
         run: dotnet build --configuration Release --no-restore
 
       - name: Create NuGet package
-        run: dotnet pack --configuration Release --no-build --output {{ env.NUGET_DIR }} --include-symbols
+        run: dotnet pack --configuration Release --no-build --output ${{ env.NUGET_DIR }} --include-symbols
 
       - name: Publish NuGet package
-        run: dotnet nuget push {{ env.NUGET_DIR }}/*.nupkg \
+        run: dotnet nuget push ${{ env.NUGET_DIR }}/*.nupkg \
           --skip-duplicate \
           --source https://api.nuget.org/v3/index.json \
           --api-key ${{ secrets.NUGET_API_KEY }}


### PR DESCRIPTION
This pull request includes a small update to the `.github/workflows/build.yaml` file. The change replaces the use of `{{ }}` for environment variables with `${{ }}` to align with GitHub Actions syntax for referencing environment variables and secrets.