### PR TITLE
fix: link in console output

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   <!-- Metadata -->
   <PropertyGroup>
-    <Version>1.0.2</Version>
+    <Version>1.0.3</Version>
     <Copyright>Copyright (c) 2025 Qase</Copyright>
     <Authors>Qase Team</Authors>
     <Company>qase.io</Company>

--- a/Qase.Csharp.Commons/reporters/TestopsReporter.cs
+++ b/Qase.Csharp.Commons/reporters/TestopsReporter.cs
@@ -141,7 +141,7 @@ namespace Qase.Csharp.Commons.Reporters
 
             if (id.HasValue)
             {
-                return baseLink + id.Value.ToString();
+                return baseLink + _config.TestOps.Project + "-" + id.Value.ToString();
             }
 
             try

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## qase-scharp 1.0.3
+
+- Fixed a link to failed test in the console output.
+
 ## qase-scharp 1.0.2
 
 - Added signature generation for test cases


### PR DESCRIPTION
This pull request includes updates to the version metadata, fixes a bug in link generation, and documents the changes in the changelog. These changes ensure better traceability and improve the functionality of the `TestopsReporter`.

### Metadata updates:
* [`Directory.Build.props`](diffhunk://#diff-9da24614831c308827a1ae533ffea392c97638c261dd42bd0f5226baa136d16eL4-R4): Updated the version from `1.0.2` to `1.0.3` to reflect the new release.

### Bug fix:
* [`Qase.Csharp.Commons/reporters/TestopsReporter.cs`](diffhunk://#diff-8bc31eb098b07a7e3c427db26080374459f30b5ad211625a605adfbc5c999f5fL144-R144): Fixed the `PrepareLink` method to include the `TestOps.Project` value in the generated link for failed tests, improving the accuracy of the console output.

### Documentation update:
* [`changelog.md`](diffhunk://#diff-3bd14d078188074c410028847113ceae68865d0ad5b844a27183ef87fbe2fcc3R3-R6): Added an entry for version `1.0.3`, documenting the fix for the link to failed tests in the console output.