### PR TITLE
docs: add detailed usage guide for Qase attributes in xUnit and update README with a reference link

### DIFF
--- a/Qase.XUnit.Reporter/README.md
+++ b/Qase.XUnit.Reporter/README.md
@@ -30,6 +30,8 @@ reliable binding between your automated tests and test cases, even if you rename
 - **`[Suites]`**: Specify the suite for the test case.
 - **`[Ignore]`**: Ignore the test case in Qase. The test will execute, but results won't be sent to Qase.
 
+For detailed instructions on using attributes and methods, refer to [Usage](docs/usage.md).
+
 ### Example Test Case
 
 Here's a simple example of using Qase annotations in an xUnit test:

--- a/Qase.XUnit.Reporter/docs/usage.md
+++ b/Qase.XUnit.Reporter/docs/usage.md
@@ -1,0 +1,182 @@
+# Qase xUnit Reporter - Usage Guide
+
+This guide explains how to use Qase attributes with xUnit to integrate your tests with Qase Test Management System.
+
+## Available Attributes
+
+### 1. QaseIds Attribute
+
+Links your test to existing test cases in Qase by their IDs.
+
+```csharp
+[Fact]
+[QaseIds(123, 456)]
+public void TestWithMultipleIds()
+{
+    // Test implementation
+}
+
+[Theory]
+[InlineData("test data")]
+[QaseIds(789)]
+public void TheoryTestWithId(string data)
+{
+    // Test implementation
+}
+```
+
+### 2. Title Attribute
+
+Sets a custom title for the test case in Qase.
+
+```csharp
+[Fact]
+[Title("Custom Test Title")]
+public void TestWithCustomTitle()
+{
+    // Test implementation
+}
+```
+
+### 3. Fields Attribute
+
+Adds custom fields to the test case.
+
+```csharp
+[Fact]
+[Fields("Priority", "High")]
+[Fields("Component", "Authentication")]
+public void TestWithCustomFields()
+{
+    // Test implementation
+}
+```
+
+### 4. Suites Attribute
+
+Specifies the suite structure for the test case.
+
+```csharp
+[Fact]
+[Suites("API", "Authentication", "Login")]
+public void TestInSpecificSuite()
+{
+    // Test implementation
+}
+```
+
+### 5. Ignore Attribute
+
+Marks the test to be ignored in Qase (test will still run but results won't be sent).
+
+```csharp
+[Fact]
+[Ignore]
+public void TestIgnoredInQase()
+{
+    // Test implementation
+}
+```
+
+## Combining Attributes
+
+You can combine multiple attributes on the same test:
+
+```csharp
+[Fact]
+[QaseIds(123)]
+[Title("User Login Test")]
+[Fields("Priority", "High")]
+[Fields("Component", "Authentication")]
+[Suites("API", "Authentication")]
+public void ComprehensiveTest()
+{
+    // Test implementation
+}
+```
+
+## Class-Level Attributes
+
+You can apply attributes at the class level to affect all tests in the class:
+
+```csharp
+[Suites("API")]
+public class AuthenticationTests
+{
+    [Fact]
+    public void Test1()
+    {
+        // This test will inherit QaseIds(100) and Suites("API")
+    }
+
+    [Fact]
+    [QaseIds(101)] // This will override the class-level QaseIds
+    public void Test2()
+    {
+        // This test will use QaseIds(101) and inherit Suites("API")
+    }
+}
+```
+
+## Theory Tests with Parameters
+
+For theory tests, parameters are automatically captured and included in the test signature:
+
+```csharp
+[Theory]
+[InlineData("user1", "password1")]
+[InlineData("user2", "password2")]
+[QaseIds(200)]
+public void LoginTest(string username, string password)
+{
+    // Test implementation
+    // Parameters will be automatically captured and sent to Qase
+}
+```
+
+## Example Test Class
+
+Here's a complete example of a test class using Qase attributes:
+
+```csharp
+using Xunit;
+using Qase.XUnit.Reporter;
+
+[Suites("API", "User Management")]
+public class UserApiTests
+{
+    [Fact]
+    [QaseIds(1001)]
+    [Title("Create User - Valid Data")]
+    [Fields("Priority", "High")]
+    [Fields("Component", "User API")]
+    public void CreateUser_WithValidData_ShouldSucceed()
+    {
+        // Test implementation
+        Assert.True(true);
+    }
+
+    [Theory]
+    [InlineData("", "password")]
+    [InlineData("username", "")]
+    [InlineData("", "")]
+    [QaseIds(1002)]
+    [Title("Create User - Invalid Data")]
+    [Fields("Priority", "Medium")]
+    public void CreateUser_WithInvalidData_ShouldFail(string username, string password)
+    {
+        // Test implementation
+        Assert.False(string.IsNullOrEmpty(username) || string.IsNullOrEmpty(password));
+    }
+
+    [Fact]
+    [QaseIds(1003)]
+    [Title("Get User by ID")]
+    [Fields("Priority", "Low")]
+    public void GetUser_ById_ShouldReturnUser()
+    {
+        // Test implementation
+        Assert.True(true);
+    }
+}
+```


### PR DESCRIPTION
This pull request enhances the documentation for the Qase xUnit Reporter by adding detailed usage instructions and examples for its attributes. It also updates the `README.md` file to include a link to the new usage guide.

### Documentation Updates:

* [`Qase.XUnit.Reporter/docs/usage.md`](diffhunk://#diff-b67d349af3673693ea18437c74aca85c5e734d46b40ee962765f2a1aa84df154R1-R182): Added a comprehensive usage guide explaining how to use Qase attributes (`QaseIds`, `Title`, `Fields`, `Suites`, and `Ignore`) with xUnit tests. Includes examples for combining attributes, class-level attributes, and theory tests with parameters.

### README Enhancements:

* [`Qase.XUnit.Reporter/README.md`](diffhunk://#diff-c0128011dfd35a368f5ea91d7b12d7b62b601342304f5133e86154e6445cb516R33-R34): Updated the README to include a link to the newly added usage guide for detailed instructions on using attributes and methods.