### PR TITLE
feat: add support for test run configurations

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   <!-- Metadata -->
   <PropertyGroup>
-    <Version>1.0.5</Version>
+    <Version>1.0.6</Version>
     <Copyright>Copyright (c) 2025 Qase</Copyright>
     <Authors>Qase Team</Authors>
     <Company>qase.io</Company>

--- a/Qase.Csharp.Commons.Tests/ClientV1Tests.cs
+++ b/Qase.Csharp.Commons.Tests/ClientV1Tests.cs
@@ -1,0 +1,265 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Qase.ApiClient.V1.Api;
+using Qase.ApiClient.V1.Model;
+using Qase.Csharp.Commons.Clients;
+using Qase.Csharp.Commons.Config;
+using Qase.Csharp.Commons.Core;
+using FluentAssertions;
+using Xunit;
+using Qase.ApiClient.V1.Model;
+
+namespace Qase.Csharp.Commons.Tests
+{
+    public class ClientV1Tests
+    {
+        [Fact]
+        public async Task CreateTestRunAsync_ShouldPassConfigurationsToRunCreate()
+        {
+            // Arrange
+            var mockLogger = new Mock<ILogger<ClientV1>>();
+            var mockRunApi = new Mock<IRunsApi>();
+            var mockAttachmentsApi = new Mock<IAttachmentsApi>();
+            var mockConfigurationsApi = new Mock<IConfigurationsApi>();
+
+            var config = new QaseConfig
+            {
+                TestOps = new TestOpsConfig
+                {
+                    Project = "TEST",
+                    Api = new ApiConfig
+                    {
+                        Token = "test-token",
+                        Host = "qase.io"
+                    },
+                    Configurations = new ConfigurationsConfig
+                    {
+                        Values = new List<ConfigurationItem> 
+                        { 
+                            new ConfigurationItem { Name = "group1", Value = "value1" },
+                            new ConfigurationItem { Name = "group2", Value = "value2" }
+                        },
+                        CreateIfNotExists = true
+                    }
+                }
+            };
+
+            var client = new ClientV1(mockLogger.Object, config, mockRunApi.Object, mockAttachmentsApi.Object, mockConfigurationsApi.Object);
+
+            // Mock successful response
+            var mockResponse = new Mock<ICreateRunApiResponse>();
+            mockResponse.Setup(x => x.IsSuccessStatusCode).Returns(true);
+            mockResponse.Setup(x => x.Ok()).Returns(new IdResponse
+            {
+                Result = new IdResponseAllOfResult
+                {
+                    Id = 12345
+                }
+            });
+
+            // Mock configurations API response
+            var mockConfigResponse = new Mock<IGetConfigurationsApiResponse>();
+            mockConfigResponse.Setup(x => x.IsSuccessStatusCode).Returns(true);
+            mockConfigResponse.Setup(x => x.Ok()).Returns(new ConfigurationListResponse
+            {
+                Result = new ConfigurationListResponseAllOfResult
+                {
+                    Entities = new List<ConfigurationGroup>
+                    {
+                        new ConfigurationGroup
+                        {
+                            Id = 1,
+                            Title = "group1",
+                            Configurations = new List<ModelConfiguration>
+                            {
+                                new ModelConfiguration { Id = 10, Title = "value1" }
+                            }
+                        },
+                        new ConfigurationGroup
+                        {
+                            Id = 2,
+                            Title = "group2",
+                            Configurations = new List<ModelConfiguration>
+                            {
+                                new ModelConfiguration { Id = 20, Title = "value2" }
+                            }
+                        }
+                    }
+                }
+            });
+
+            mockConfigurationsApi.Setup(x => x.GetConfigurationsAsync(It.IsAny<string>(), It.IsAny<System.Threading.CancellationToken>()))
+                .ReturnsAsync(mockConfigResponse.Object);
+
+            mockRunApi.Setup(x => x.CreateRunAsync(It.IsAny<string>(), It.IsAny<RunCreate>(), It.IsAny<System.Threading.CancellationToken>()))
+                .ReturnsAsync(mockResponse.Object);
+
+            // Act
+            var result = await client.CreateTestRunAsync();
+
+            // Assert
+            result.Should().Be(12345);
+            mockRunApi.Verify(x => x.CreateRunAsync(
+                It.Is<string>(p => p == "TEST"),
+                It.Is<RunCreate>(r => r.Configurations != null && r.Configurations.Count == 2 && 
+                                     r.Configurations.Contains(10) && r.Configurations.Contains(20)),
+                It.IsAny<System.Threading.CancellationToken>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task CreateTestRunAsync_ShouldNotPassConfigurations_WhenConfigurationsIsEmpty()
+        {
+            // Arrange
+            var mockLogger = new Mock<ILogger<ClientV1>>();
+            var mockRunApi = new Mock<IRunsApi>();
+            var mockAttachmentsApi = new Mock<IAttachmentsApi>();
+            var mockConfigurationsApi = new Mock<IConfigurationsApi>();
+
+            var config = new QaseConfig
+            {
+                TestOps = new TestOpsConfig
+                {
+                    Project = "TEST",
+                    Api = new ApiConfig
+                    {
+                        Token = "test-token",
+                        Host = "qase.io"
+                    },
+                    Configurations = new ConfigurationsConfig
+                    {
+                        Values = new List<ConfigurationItem>(), // Empty configurations
+                        CreateIfNotExists = true
+                    }
+                }
+            };
+
+            var client = new ClientV1(mockLogger.Object, config, mockRunApi.Object, mockAttachmentsApi.Object, mockConfigurationsApi.Object);
+
+            // Mock successful response
+            var mockResponse = new Mock<ICreateRunApiResponse>();
+            mockResponse.Setup(x => x.IsSuccessStatusCode).Returns(true);
+            mockResponse.Setup(x => x.Ok()).Returns(new IdResponse
+            {
+                Result = new IdResponseAllOfResult
+                {
+                    Id = 12345
+                }
+            });
+
+            mockRunApi.Setup(x => x.CreateRunAsync(It.IsAny<string>(), It.IsAny<RunCreate>(), It.IsAny<System.Threading.CancellationToken>()))
+                .ReturnsAsync(mockResponse.Object);
+
+            // Act
+            var result = await client.CreateTestRunAsync();
+
+            // Assert
+            result.Should().Be(12345);
+            mockRunApi.Verify(x => x.CreateRunAsync(
+                It.Is<string>(p => p == "TEST"),
+                It.Is<RunCreate>(r => r.Configurations == null || r.Configurations.Count == 0),
+                It.IsAny<System.Threading.CancellationToken>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task CreateTestRunAsync_ShouldPassTagsAndConfigurations()
+        {
+            // Arrange
+            var mockLogger = new Mock<ILogger<ClientV1>>();
+            var mockRunApi = new Mock<IRunsApi>();
+            var mockAttachmentsApi = new Mock<IAttachmentsApi>();
+            var mockConfigurationsApi = new Mock<IConfigurationsApi>();
+
+            var config = new QaseConfig
+            {
+                TestOps = new TestOpsConfig
+                {
+                    Project = "TEST",
+                    Api = new ApiConfig
+                    {
+                        Token = "test-token",
+                        Host = "qase.io"
+                    },
+                    Run = new RunConfig
+                    {
+                        Tags = new List<string> { "tag1", "tag2" }
+                    },
+                    Configurations = new ConfigurationsConfig
+                    {
+                        Values = new List<ConfigurationItem> 
+                        { 
+                            new ConfigurationItem { Name = "group1", Value = "value1" },
+                            new ConfigurationItem { Name = "group2", Value = "value2" }
+                        },
+                        CreateIfNotExists = true
+                    }
+                }
+            };
+
+            var client = new ClientV1(mockLogger.Object, config, mockRunApi.Object, mockAttachmentsApi.Object, mockConfigurationsApi.Object);
+
+            // Mock successful response
+            var mockResponse = new Mock<ICreateRunApiResponse>();
+            mockResponse.Setup(x => x.IsSuccessStatusCode).Returns(true);
+            mockResponse.Setup(x => x.Ok()).Returns(new IdResponse
+            {
+                Result = new IdResponseAllOfResult
+                {
+                    Id = 12345
+                }
+            });
+
+            // Mock configurations API response
+            var mockConfigResponse = new Mock<IGetConfigurationsApiResponse>();
+            mockConfigResponse.Setup(x => x.IsSuccessStatusCode).Returns(true);
+            mockConfigResponse.Setup(x => x.Ok()).Returns(new ConfigurationListResponse
+            {
+                Result = new ConfigurationListResponseAllOfResult
+                {
+                    Entities = new List<ConfigurationGroup>
+                    {
+                        new ConfigurationGroup
+                        {
+                            Id = 1,
+                            Title = "group1",
+                            Configurations = new List<ModelConfiguration>
+                            {
+                                new ModelConfiguration { Id = 10, Title = "value1" }
+                            }
+                        },
+                        new ConfigurationGroup
+                        {
+                            Id = 2,
+                            Title = "group2",
+                            Configurations = new List<ModelConfiguration>
+                            {
+                                new ModelConfiguration { Id = 20, Title = "value2" }
+                            }
+                        }
+                    }
+                }
+            });
+
+            mockConfigurationsApi.Setup(x => x.GetConfigurationsAsync(It.IsAny<string>(), It.IsAny<System.Threading.CancellationToken>()))
+                .ReturnsAsync(mockConfigResponse.Object);
+
+            mockRunApi.Setup(x => x.CreateRunAsync(It.IsAny<string>(), It.IsAny<RunCreate>(), It.IsAny<System.Threading.CancellationToken>()))
+                .ReturnsAsync(mockResponse.Object);
+
+            // Act
+            var result = await client.CreateTestRunAsync();
+
+            // Assert
+            result.Should().Be(12345);
+            mockRunApi.Verify(x => x.CreateRunAsync(
+                It.Is<string>(p => p == "TEST"),
+                It.Is<RunCreate>(r => 
+                    r.Tags != null && r.Tags.Count == 2 && r.Tags.Contains("tag1") && r.Tags.Contains("tag2") &&
+                    r.Configurations != null && r.Configurations.Count == 2 && 
+                    r.Configurations.Contains(10) && r.Configurations.Contains(20)),
+                It.IsAny<System.Threading.CancellationToken>()), Times.Once);
+        }
+    }
+} 

--- a/Qase.Csharp.Commons.Tests/ClientV2InternalsTests.cs
+++ b/Qase.Csharp.Commons.Tests/ClientV2InternalsTests.cs
@@ -20,6 +20,7 @@ namespace Qase.Csharp.Commons.Tests
         private readonly Mock<ILogger<ClientV1>> _clientV1LoggerMock = new();
         private readonly Mock<IRunsApi> _runsApiMock = new();
         private readonly Mock<IAttachmentsApi> _attachmentsApiMock = new();
+        private readonly Mock<IConfigurationsApi> _configurationsApiMock = new();
         private readonly Mock<Qase.ApiClient.V2.Api.IResultsApi> _resultsApiMock = new();
         private readonly QaseConfig _config;
         private readonly ClientV1 _clientV1;
@@ -40,7 +41,7 @@ namespace Qase.Csharp.Commons.Tests
                 }
             };
             
-            _clientV1 = new ClientV1(_clientV1LoggerMock.Object, _config, _runsApiMock.Object, _attachmentsApiMock.Object);
+            _clientV1 = new ClientV1(_clientV1LoggerMock.Object, _config, _runsApiMock.Object, _attachmentsApiMock.Object, _configurationsApiMock.Object);
             _client = new ClientV2(_loggerMock.Object, _config, _clientV1, _resultsApiMock.Object);
         }
 

--- a/Qase.Csharp.Commons.Tests/ConfigFactoryTests.cs
+++ b/Qase.Csharp.Commons.Tests/ConfigFactoryTests.cs
@@ -424,5 +424,185 @@ namespace Qase.Csharp.Commons.Tests
             config.Report.Connection.Local.Format.Should().Be(Format.Json);
             config.Report.Connection.Local.Path.Should().Be("/complex/report/path");
         }
+
+        [Fact]
+        public void LoadConfig_ShouldLoadConfigurationsFromJsonFile()
+        {
+            // Arrange
+            var jsonConfig = @"{
+  ""testops"": {
+    ""configurations"": {
+      ""values"": [
+        {
+          ""name"": ""group1"",
+          ""value"": ""value1""
+        },
+        {
+          ""name"": ""group2"",
+          ""value"": ""value2""
+        }
+      ],
+      ""createIfNotExists"": true
+    }
+  }
+}";
+            File.WriteAllText(ConfigFileName, jsonConfig);
+
+            // Act
+            var config = ConfigFactory.LoadConfig();
+
+            // Assert
+            config.TestOps.Configurations.Values.Should().HaveCount(2);
+            config.TestOps.Configurations.Values[0].Name.Should().Be("group1");
+            config.TestOps.Configurations.Values[0].Value.Should().Be("value1");
+            config.TestOps.Configurations.Values[1].Name.Should().Be("group2");
+            config.TestOps.Configurations.Values[1].Value.Should().Be("value2");
+            config.TestOps.Configurations.CreateIfNotExists.Should().BeTrue();
+        }
+
+        [Fact]
+        public void LoadConfig_ShouldLoadConfigurationsFromEnvironmentVariable()
+        {
+            // Arrange
+            Environment.SetEnvironmentVariable("QASE_TESTOPS_CONFIGURATIONS_VALUES", "group1=value1,group2=value2,group3=value3");
+
+            // Act
+            var config = ConfigFactory.LoadConfig();
+
+            // Assert
+            config.TestOps.Configurations.Values.Should().HaveCount(3);
+            config.TestOps.Configurations.Values[0].Name.Should().Be("group1");
+            config.TestOps.Configurations.Values[0].Value.Should().Be("value1");
+            config.TestOps.Configurations.Values[1].Name.Should().Be("group2");
+            config.TestOps.Configurations.Values[1].Value.Should().Be("value2");
+            config.TestOps.Configurations.Values[2].Name.Should().Be("group3");
+            config.TestOps.Configurations.Values[2].Value.Should().Be("value3");
+
+            // Cleanup
+            Environment.SetEnvironmentVariable("QASE_TESTOPS_CONFIGURATIONS_VALUES", null);
+        }
+
+        [Fact]
+        public void LoadConfig_ShouldHandleInvalidConfigurationsInEnvironmentVariable()
+        {
+            // Arrange
+            Environment.SetEnvironmentVariable("QASE_TESTOPS_CONFIGURATIONS_VALUES", "10,invalid,30");
+
+            // Act
+            var config = ConfigFactory.LoadConfig();
+
+            // Assert
+            config.TestOps.Configurations.Values.Should().BeEmpty();
+
+            // Cleanup
+            Environment.SetEnvironmentVariable("QASE_TESTOPS_CONFIGURATIONS_VALUES", null);
+        }
+
+        [Fact]
+        public void LoadConfig_ShouldHandleEmptyConfigurationsInEnvironmentVariable()
+        {
+            // Arrange
+            Environment.SetEnvironmentVariable("QASE_TESTOPS_CONFIGURATIONS_VALUES", "");
+
+            // Act
+            var config = ConfigFactory.LoadConfig();
+
+            // Assert
+            config.TestOps.Configurations.Values.Should().BeEmpty();
+
+            // Cleanup
+            Environment.SetEnvironmentVariable("QASE_TESTOPS_CONFIGURATIONS_VALUES", null);
+        }
+
+        [Fact]
+        public void LoadConfig_ShouldHandleConfigurationsWithSpacesInEnvironmentVariable()
+        {
+            // Arrange
+            Environment.SetEnvironmentVariable("QASE_TESTOPS_CONFIGURATIONS_VALUES", " group1 = value1 , group2 = value2 ");
+
+            // Act
+            var config = ConfigFactory.LoadConfig();
+
+            // Assert
+            config.TestOps.Configurations.Values.Should().HaveCount(2);
+            config.TestOps.Configurations.Values[0].Name.Should().Be("group1");
+            config.TestOps.Configurations.Values[0].Value.Should().Be("value1");
+            config.TestOps.Configurations.Values[1].Name.Should().Be("group2");
+            config.TestOps.Configurations.Values[1].Value.Should().Be("value2");
+
+            // Cleanup
+            Environment.SetEnvironmentVariable("QASE_TESTOPS_CONFIGURATIONS_VALUES", null);
+        }
+
+        [Fact]
+        public void LoadConfig_ShouldLoadConfigurationsCreateIfNotExistsFromEnvironmentVariable()
+        {
+            // Arrange
+            Environment.SetEnvironmentVariable("QASE_TESTOPS_CONFIGURATIONS_CREATE_IF_NOT_EXISTS", "true");
+
+            // Act
+            var config = ConfigFactory.LoadConfig();
+
+            // Assert
+            config.TestOps.Configurations.CreateIfNotExists.Should().BeTrue();
+
+            // Cleanup
+            Environment.SetEnvironmentVariable("QASE_TESTOPS_CONFIGURATIONS_CREATE_IF_NOT_EXISTS", null);
+        }
+
+        [Fact]
+        public void LoadConfig_ShouldLoadConfigurationsCreateIfNotExistsFromJsonFile()
+        {
+            // Arrange
+            var jsonConfig = @"{
+  ""testops"": {
+    ""configurations"": {
+      ""createIfNotExists"": true
+    }
+  }
+}";
+            File.WriteAllText(ConfigFileName, jsonConfig);
+
+            // Act
+            var config = ConfigFactory.LoadConfig();
+
+            // Assert
+            config.TestOps.Configurations.CreateIfNotExists.Should().BeTrue();
+        }
+
+        [Fact]
+        public void LoadConfig_ShouldLoadConfigurationsWithValuesAndCreateIfNotExistsFromJsonFile()
+        {
+            // Arrange
+            var jsonConfig = @"{
+  ""testops"": {
+    ""configurations"": {
+      ""values"": [
+        {
+          ""name"": ""group1"",
+          ""value"": ""value1""
+        },
+        {
+          ""name"": ""group2"",
+          ""value"": ""value2""
+        }
+      ],
+      ""createIfNotExists"": true
+    }
+  }
+}";
+            File.WriteAllText(ConfigFileName, jsonConfig);
+
+            // Act
+            var config = ConfigFactory.LoadConfig();
+
+            // Assert
+            config.TestOps.Configurations.Values.Should().HaveCount(2);
+            config.TestOps.Configurations.Values[0].Name.Should().Be("group1");
+            config.TestOps.Configurations.Values[0].Value.Should().Be("value1");
+            config.TestOps.Configurations.Values[1].Name.Should().Be("group2");
+            config.TestOps.Configurations.Values[1].Value.Should().Be("value2");
+            config.TestOps.Configurations.CreateIfNotExists.Should().BeTrue();
+        }
     }
 } 

--- a/Qase.Csharp.Commons/README.md
+++ b/Qase.Csharp.Commons/README.md
@@ -44,6 +44,8 @@ All configuration options are listed in the table below:
 | Qase test plan ID                                                                                                          | `testops.plan.id`          | `QASE_TESTOPS_PLAN_ID`          | `QASE_TESTOPS_PLAN_ID`          | undefined                               | No       | Any integer                |
 | Size of batch for sending test results                                                                                     | `testops.batch.size`       | `QASE_TESTOPS_BATCH_SIZE`       | `QASE_TESTOPS_BATCH_SIZE`       | `200`                                   | No       | Any integer                |
 | Enable defects for failed test cases                                                                                       | `testops.defect`           | `QASE_TESTOPS_DEFECT`           | `QASE_TESTOPS_DEFECT`           | `False`                                 | No       | `True`, `False`            |
+| Configuration values for test run                                                                                          | `testops.configurations.values` | `QASE_TESTOPS_CONFIGURATIONS_VALUES` | `QASE_TESTOPS_CONFIGURATIONS_VALUES` | `[]`                                    | No       | Comma-separated key=value pairs |
+| Whether to create configuration groups and values if they don't exist                                                      | `testops.configurations.createIfNotExists` | `QASE_TESTOPS_CONFIGURATIONS_CREATE_IF_NOT_EXISTS` | `QASE_TESTOPS_CONFIGURATIONS_CREATE_IF_NOT_EXISTS` | `False`                                 | No       | `True`, `False`            |
 
 ### Example `qase.config.json` config
 
@@ -78,6 +80,19 @@ All configuration options are listed in the table below:
     "project": "<project_code>",
     "batch": {
       "size": 100
+    },
+    "configurations": {
+      "values": [
+        {
+          "name": "Browser",
+          "value": "Chrome"
+        },
+        {
+          "name": "Environment",
+          "value": "Production"
+        }
+      ],
+      "createIfNotExists": true
     }
   }
 }

--- a/Qase.Csharp.Commons/ServiceCollectionExtensions.cs
+++ b/Qase.Csharp.Commons/ServiceCollectionExtensions.cs
@@ -86,8 +86,9 @@ namespace Qase.Csharp.Commons
                 var apiServiceProvider = apiServices.BuildServiceProvider();
                 var runApi = apiServiceProvider.GetRequiredService<IRunsApi>();
                 var attachmentsApi = apiServiceProvider.GetRequiredService<IAttachmentsApi>();
+                var configurationsApi = apiServiceProvider.GetRequiredService<IConfigurationsApi>();
                 
-                return new ClientV1(logger, config, runApi, attachmentsApi);
+                return new ClientV1(logger, config, runApi, attachmentsApi, configurationsApi);
             });
 
             services.AddSingleton<ClientV2>(sp =>

--- a/Qase.Csharp.Commons/config/ConfigurationItem.cs
+++ b/Qase.Csharp.Commons/config/ConfigurationItem.cs
@@ -1,0 +1,18 @@
+namespace Qase.Csharp.Commons.Config
+{
+    /// <summary>
+    /// Represents a configuration item with name and value
+    /// </summary>
+    public class ConfigurationItem
+    {
+        /// <summary>
+        /// Gets or sets the configuration name
+        /// </summary>
+        public string Name { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the configuration value
+        /// </summary>
+        public string Value { get; set; } = string.Empty;
+    }
+} 

--- a/Qase.Csharp.Commons/config/ConfigurationsConfig.cs
+++ b/Qase.Csharp.Commons/config/ConfigurationsConfig.cs
@@ -1,0 +1,20 @@
+using System.Collections.Generic;
+
+namespace Qase.Csharp.Commons.Config
+{
+    /// <summary>
+    /// Configurations block for TestOps config
+    /// </summary>
+    public class ConfigurationsConfig
+    {
+        /// <summary>
+        /// List of configuration items (group+value)
+        /// </summary>
+        public List<ConfigurationItem> Values { get; set; } = new();
+
+        /// <summary>
+        /// Whether to create group/config if not exists
+        /// </summary>
+        public bool CreateIfNotExists { get; set; } = false;
+    }
+} 

--- a/Qase.Csharp.Commons/config/TestopsConfig.cs
+++ b/Qase.Csharp.Commons/config/TestopsConfig.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+
 namespace Qase.Csharp.Commons.Config
 {
     /// <summary>
@@ -34,5 +36,10 @@ namespace Qase.Csharp.Commons.Config
         /// Gets or sets the plan config
         /// </summary>
         public PlanConfig Plan { get; set; } = new PlanConfig();
+
+        /// <summary>
+        /// Gets or sets the configurations
+        /// </summary>
+        public ConfigurationsConfig Configurations { get; set; } = new ConfigurationsConfig();
     }
 }

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## qase-scharp 1.0.6
+
+- Added support for test run configurations
+
 ## qase-scharp 1.0.5
 
 - Added support for file attachments upload


### PR DESCRIPTION
This pull request introduces support for configuration groups and values in test runs, along with enhancements to configuration handling and updates to related tests and documentation. The changes include extending the `ClientV1` class to manage configurations, adding new tests for configuration-related functionality, and updating the documentation to reflect the new configuration options.

### Configuration Support

* [`Qase.Csharp.Commons/clients/ClientV1.cs`](diffhunk://#diff-b3772036e84585026f4c74b75bf14fd6e41b0111e98818f565375d619d408b3dR24): Added support for configuration groups and values in test runs by introducing a new `_configurationsApi` dependency and modifying the `CreateTestRunAsync` method to include configuration IDs if available. [[1]](diffhunk://#diff-b3772036e84585026f4c74b75bf14fd6e41b0111e98818f565375d619d408b3dR24) [[2]](diffhunk://#diff-b3772036e84585026f4c74b75bf14fd6e41b0111e98818f565375d619d408b3dL37-R45) [[3]](diffhunk://#diff-b3772036e84585026f4c74b75bf14fd6e41b0111e98818f565375d619d408b3dR70-R78)

### Test Enhancements

* [`Qase.Csharp.Commons.Tests/ClientV1Tests.cs`](diffhunk://#diff-fc1c0caf80bc40af093f92d79a568fb97a4df8c67a9b287105b722100f302eaaR1-R265): Added multiple test cases to verify the behavior of the `CreateTestRunAsync` method with configurations, including scenarios with empty configurations, tags, and configurations loaded from JSON or environment variables.
* [`Qase.Csharp.Commons.Tests/ConfigFactoryTests.cs`](diffhunk://#diff-cc33c7e4d9fbb7ab2e67785e2a5aa2ef8943d2a2401953e551b02731a056a600R427-R606): Added tests to validate configuration loading from JSON files and environment variables, including handling of invalid or empty configurations.

### Documentation Updates

* [`Qase.Csharp.Commons/README.md`](diffhunk://#diff-9a75421a489d96c59d5b55d0acdb82c52406bdb1522c80c65b7a1ea025670956R47-R48): Updated the documentation to include new configuration options (`testops.configurations.values` and `testops.configurations.createIfNotExists`) and provided examples of their usage in JSON configuration files. [[1]](diffhunk://#diff-9a75421a489d96c59d5b55d0acdb82c52406bdb1522c80c65b7a1ea025670956R47-R48) [[2]](diffhunk://#diff-9a75421a489d96c59d5b55d0acdb82c52406bdb1522c80c65b7a1ea025670956R83-R95)

### Dependency Injection Updates

* [`Qase.Csharp.Commons/ServiceCollectionExtensions.cs`](diffhunk://#diff-a26742b613a4318fe85ab4b6c3981c021472114ce279f1ab5d74e519bd2ccadaR89-R91): Modified the `AddQaseServices` method to include the `IConfigurationsApi` dependency when creating `ClientV1`.

### Minor Updates

* [`Directory.Build.props`](diffhunk://#diff-9da24614831c308827a1ae533ffea392c97638c261dd42bd0f5226baa136d16eL4-R4): Incremented the version number from `1.0.5` to `1.0.6`.