### PR TITLE
feat: update to version 1.0.9, improve test result status logic, and add unit tests for assertion failure detection

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   <!-- Metadata -->
   <PropertyGroup>
-    <Version>1.0.8</Version>
+    <Version>1.0.9</Version>
     <Copyright>Copyright (c) 2025 Qase</Copyright>
     <Authors>Qase Team</Authors>
     <Company>qase.io</Company>

--- a/Qase.Csharp.Commons/Qase.Csharp.Commons.csproj
+++ b/Qase.Csharp.Commons/Qase.Csharp.Commons.csproj
@@ -13,6 +13,8 @@
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <DebugType>portable</DebugType>
+    <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Qase.Csharp.Commons/clients/ClientV2.cs
+++ b/Qase.Csharp.Commons/clients/ClientV2.cs
@@ -264,6 +264,8 @@ namespace Qase.Csharp.Commons.Clients
                     return "failed";
                 case TestResultStatus.Skipped:
                     return "skipped";
+                case TestResultStatus.Invalid:
+                    return "invalid";
                 default:
                     return "failed";
             }

--- a/Qase.Csharp.Commons/models/domain/TestResultStatus.cs
+++ b/Qase.Csharp.Commons/models/domain/TestResultStatus.cs
@@ -18,6 +18,11 @@ namespace Qase.Csharp.Commons.Models.Domain
         /// <summary>
         /// Test skipped
         /// </summary>
-        Skipped
+        Skipped,
+
+        /// <summary>
+        /// Test invalid (failed due to non-assertion reasons)
+        /// </summary>
+        Invalid
     }
 } 

--- a/Qase.XUnit.Reporter.Tests/QaseMessageSinkTests.cs
+++ b/Qase.XUnit.Reporter.Tests/QaseMessageSinkTests.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Collections.Generic;
+using Xunit;
+using Xunit.Abstractions;
+using Qase.Xunit.Reporter;
+using Moq;
+
+namespace Qase.XUnit.Reporter.Tests
+{
+    public class QaseMessageSinkTests
+    {
+        [Fact]
+        public void IsAssertionFailure_WithAssertEqualInStackTrace_ShouldReturnTrue()
+        {
+            // Arrange
+            var mockTestFailed = new Mock<ITestFailed>();
+            var stackTraces = new List<string>
+            {
+                "   at Xunit.Assert.Equal[T](T expected, T actual, IEqualityComparer`1 comparer) in /_/src/xunit.assert/Asserts/EqualityAsserts.cs:line 154",
+                "   at Xunit.Assert.Equal[T](T expected, T actual) in /_/src/xunit.assert/Asserts/EqualityAsserts.cs:line 89",
+                "   at xUnitExamples.FailureTypeTests.TestWithAssertionFailure() in /Users/gda/Documents/github/qase-tms/qase-csharp/examples/xUnitExamples/FailureTypeTests.cs:line 16"
+            };
+            mockTestFailed.Setup(x => x.StackTraces).Returns(stackTraces);
+
+            // Act
+            var result = QaseMessageSink.IsAssertionFailure(mockTestFailed.Object);
+
+            // Assert
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void IsAssertionFailure_WithExceptionInStackTrace_ShouldReturnFalse()
+        {
+            // Arrange
+            var mockTestFailed = new Mock<ITestFailed>();
+            var stackTraces = new List<string>
+            {
+                "   at xUnitExamples.FailureTypeTests.TestWithExceptionFailure() in /Users/gda/Documents/github/qase-tms/qase-csharp/examples/xUnitExamples/FailureTypeTests.cs:line 25",
+                "   at System.RuntimeMethodHandle.InvokeMethod(Object target, Void** arguments, Signature sig, Boolean isConstructor)",
+                "   at System.Reflection.MethodBaseInvoker.InvokeWithNoArgs(Object obj, BindingFlags invokeAttr)"
+            };
+            mockTestFailed.Setup(x => x.StackTraces).Returns(stackTraces);
+
+            // Act
+            var result = QaseMessageSink.IsAssertionFailure(mockTestFailed.Object);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void IsAssertionFailure_WithAssertFailInStackTrace_ShouldReturnTrue()
+        {
+            // Arrange
+            var mockTestFailed = new Mock<ITestFailed>();
+            var stackTraces = new List<string>
+            {
+                "   at Xunit.Assert.Fail(String message) in /_/src/xunit.assert/Asserts/FailAsserts.cs:line 38",
+                "   at xUnitExamples.FailureTypeTests.TestWithMultipleAssertionFailures() in /Users/gda/Documents/github/qase-tms/qase-csharp/examples/xUnitExamples/FailureTypeTests.cs:line 62"
+            };
+            mockTestFailed.Setup(x => x.StackTraces).Returns(stackTraces);
+
+            // Act
+            var result = QaseMessageSink.IsAssertionFailure(mockTestFailed.Object);
+
+            // Assert
+            Assert.True(result);
+        }
+    }
+}

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## qase-scharp 1.0.9
+
+- Improved the logic for determining the status of a test result
+- Added support for the `Invalid` status
+
 ## qase-scharp 1.0.7
 
 - Updated API clients to the latest specification versions


### PR DESCRIPTION
This pull request introduces improvements to test result status handling and adds support for distinguishing assertion failures from other types of test failures. The main changes include the addition of a new `Invalid` test result status, logic to classify failures as assertion-based or not, and corresponding updates to reporting and tests.

**Test result status enhancements:**

* Added a new `Invalid` status to the `TestResultStatus` enum to represent test failures due to non-assertion reasons. (`Qase.Csharp.Commons/models/domain/TestResultStatus.cs`, [Qase.Csharp.Commons/models/domain/TestResultStatus.csL21-R26](diffhunk://#diff-48419b464c95d1ceabf6fbff65045ce7f5979cfd1676c2de70fd85f3c82a62e6L21-R26))
* Updated the `MapStatus` method in `ClientV2.cs` to handle the new `Invalid` status and return the appropriate string value. (`Qase.Csharp.Commons/clients/ClientV2.cs`, [Qase.Csharp.Commons/clients/ClientV2.csR267-R268](diffhunk://#diff-f891989a0f45c40b3e95e9c497ca5cda2e8bfc6c7fd8bb5526e4257c81e22f34R267-R268))

**Failure classification logic:**

* Implemented the `IsAssertionFailure` method in `QaseMessageSink.cs` to determine if a test failure was caused by an assertion, based on the stack trace. (`Qase.XUnit.Reporter/QaseMessageSink.cs`, [Qase.XUnit.Reporter/QaseMessageSink.csR181-R221](diffhunk://#diff-3bda178542e8515b5225fa1c926479085c8f29f140646786eb68c23d98b32093R181-R221))
* Updated failure handling in `QaseMessageSink.cs` to set the test result status to `Invalid` for non-assertion failures, and to `Failed` for assertion failures. (`Qase.XUnit.Reporter/QaseMessageSink.cs`, [Qase.XUnit.Reporter/QaseMessageSink.csL66-R70](diffhunk://#diff-3bda178542e8515b5225fa1c926479085c8f29f140646786eb68c23d98b32093L66-R70))

**Testing and documentation:**

* Added unit tests for the new assertion failure detection logic in `QaseMessageSinkTests.cs`. (`Qase.XUnit.Reporter.Tests/QaseMessageSinkTests.cs`, [Qase.XUnit.Reporter.Tests/QaseMessageSinkTests.csR1-R71](diffhunk://#diff-30929ea04107ee8e36d33b6cc74f2f3ebc336a1f000ec1ccdfd953d9bc1220d5R1-R71))
* Updated the changelog to document the new `Invalid` status and improved test result status logic. (`changelog.md`, [changelog.mdR3-R7](diffhunk://#diff-3bd14d078188074c410028847113ceae68865d0ad5b844a27183ef87fbe2fcc3R3-R7))

**Build configuration:**

* Enabled portable debug symbols in the project file for improved debugging support. (`Qase.Csharp.Commons/Qase.Csharp.Commons.csproj`, [Qase.Csharp.Commons/Qase.Csharp.Commons.csprojR16-R17](diffhunk://#diff-964f461880280ccbd4b6209f2a190f4958e20cea0c30346c5b54d6a56528874bR16-R17))
* Bumped the package version to `1.0.9` in `Directory.Build.props`. (`Directory.Build.props`, [Directory.Build.propsL4-R4](diffhunk://#diff-9da24614831c308827a1ae533ffea392c97638c261dd42bd0f5226baa136d16eL4-R4))