### PR TITLE
Fix namespace imports in code example for XUnit reporter

### DIFF
--- a/Qase.XUnit.Reporter/README.md
+++ b/Qase.XUnit.Reporter/README.md
@@ -38,8 +38,10 @@ For detailed instructions on using attributes and methods, refer to [Usage](docs
 Here's a simple example of using Qase annotations in an xUnit test:
 
 ```csharp
+using System;
 using Xunit;
-using Qase.XUnit.Reporter;
+using Qase.Xunit.Reporter;
+using Qase.Csharp.Commons.Attributes;
 
 [Suites("Example Suite", "Example Suite 2")]
 [Fields("preconditions", "This is a precondition")]
@@ -69,6 +71,7 @@ public class SimpleTests
     {
         Console.WriteLine($"Running test with {a} and {b}");
     }
+}
 ```
 
 To execute your xUnit tests and report the results to Qase.io, use the following command:


### PR DESCRIPTION
Hello! I’m new to C# and spent a few hours integrating my XUnit tests with the Qase reporter. I discovered that there are mistakes in the imports in the README file.

This PR will fix the imports in that example. Specifically, it will correct the namespace for `Qase.Xunit.Reporter` and add an import for `Qase.Csharp.Commons.Attributes` to enable the use of attributes.