### PR TITLE
feat: add Tags attribute for assigning tags to test results

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   <!-- Metadata -->
   <PropertyGroup>
-    <Version>1.1.14</Version>
+    <Version>1.1.15</Version>
     <Copyright>Copyright (c) 2025 Qase</Copyright>
     <Authors>Qase Team</Authors>
     <Company>qase.io</Company>

--- a/Qase.Csharp.Commons.Tests/AttributeExtractorTests.cs
+++ b/Qase.Csharp.Commons.Tests/AttributeExtractorTests.cs
@@ -119,6 +119,8 @@ namespace Qase.Csharp.Commons.Tests
             result.Relations!.Suite.Data.Should().HaveCount(2);
             // Note: FullyAnnotatedFixture does not have [Ignore], so Ignore stays false
             result.Ignore.Should().BeFalse();
+            result.Tags.Should().Contain("tag1");
+            result.Tags.Should().Contain("tag2");
         }
 
         [Fact]
@@ -187,6 +189,70 @@ namespace Qase.Csharp.Commons.Tests
             result.TestopsIds.Should().BeNull();
             result.Fields.Should().BeEmpty();
             result.Ignore.Should().BeFalse();
+        }
+
+        // === ATTR-04: Tags extraction ===
+
+        [Fact]
+        public void Apply_WithTags_PopulatesTags()
+        {
+            // Arrange
+            var methodAttrs = GetMethodQaseAttributes(typeof(FullyAnnotatedFixture), "AnnotatedMethod");
+            var result = new TestResult();
+
+            // Act
+            AttributeExtractor.Apply(Enumerable.Empty<Attribute>(), methodAttrs, result);
+
+            // Assert
+            result.Tags.Should().Contain("tag1");
+            result.Tags.Should().Contain("tag2");
+        }
+
+        [Fact]
+        public void Apply_TagsFromClassAndMethod_AreMerged()
+        {
+            // Arrange
+            var classAttrs = GetClassQaseAttributes(typeof(ClassAndMethodAttributeFixture));
+            var methodAttrs = GetMethodQaseAttributes(typeof(ClassAndMethodAttributeFixture), "MethodWithOverrides");
+            var result = new TestResult();
+
+            // Act
+            AttributeExtractor.Apply(classAttrs, methodAttrs, result);
+
+            // Assert -- tags from class and method are merged, not overwritten
+            result.Tags.Should().Contain("class-tag");
+            result.Tags.Should().Contain("method-tag");
+        }
+
+        [Fact]
+        public void Apply_ClassTagsPreservedForPlainMethod()
+        {
+            // Arrange -- PlainMethod has no method-level Tags attribute
+            var classAttrs = GetClassQaseAttributes(typeof(ClassAndMethodAttributeFixture));
+            var methodAttrs = GetMethodQaseAttributes(typeof(ClassAndMethodAttributeFixture), "PlainMethod");
+            var result = new TestResult();
+
+            // Act
+            AttributeExtractor.Apply(classAttrs, methodAttrs, result);
+
+            // Assert -- class-level [Tags("class-tag")] is preserved
+            result.Tags.Should().Contain("class-tag");
+        }
+
+        [Fact]
+        public void Apply_WithEmptyCollections_TagsStayEmpty()
+        {
+            // Arrange
+            var result = new TestResult();
+
+            // Act
+            AttributeExtractor.Apply(
+                Enumerable.Empty<Attribute>(),
+                Enumerable.Empty<Attribute>(),
+                result);
+
+            // Assert
+            result.Tags.Should().BeEmpty();
         }
 
         // === ATTR-02: Indexer semantics for Fields (duplicate key handling) ===

--- a/Qase.Csharp.Commons.Tests/Fixtures/TestFixtures.cs
+++ b/Qase.Csharp.Commons.Tests/Fixtures/TestFixtures.cs
@@ -39,6 +39,7 @@ namespace Qase.Csharp.Commons.Tests.Fixtures
         [Title("Custom Title")]
         [Fields("env", "staging")]
         [Suites("Login", "Auth")]
+        [Tags("tag1", "tag2")]
         public void AnnotatedMethod() { }
     }
 
@@ -50,11 +51,13 @@ namespace Qase.Csharp.Commons.Tests.Fixtures
     [Fields("priority", "high")]
     [Suites("ClassSuite")]
     [Ignore]
+    [Tags("class-tag")]
     public class ClassAndMethodAttributeFixture
     {
         [Fields("env", "production")]
         [Fields("browser", "chrome")]
         [Suites("MethodSuite")]
+        [Tags("method-tag")]
         public void MethodWithOverrides() { }
 
         public void PlainMethod() { }

--- a/Qase.Csharp.Commons/Attributes/TagsAttribute.cs
+++ b/Qase.Csharp.Commons/Attributes/TagsAttribute.cs
@@ -1,0 +1,17 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Qase.Csharp.Commons.Attributes
+{
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class, AllowMultiple = true)]
+    public class TagsAttribute : Attribute, IQaseAttribute
+    {
+        public List<string> Tags { get; }
+
+        public TagsAttribute(params string[] tags)
+        {
+            Tags = tags.ToList();
+        }
+    }
+}

--- a/Qase.Csharp.Commons/Utils/AttributeExtractor.cs
+++ b/Qase.Csharp.Commons/Utils/AttributeExtractor.cs
@@ -52,6 +52,9 @@ namespace Qase.Csharp.Commons.Utils
                             .Select(s => new SuiteData { Title = s })
                             .ToList();
                         break;
+                    case TagsAttribute tags:
+                        testResult.Tags.AddRange(tags.Tags);
+                        break;
                     case IgnoreAttribute:
                         testResult.Ignore = true;
                         break;

--- a/Qase.Csharp.Commons/clients/ClientV2.cs
+++ b/Qase.Csharp.Commons/clients/ClientV2.cs
@@ -195,6 +195,9 @@ namespace Qase.Csharp.Commons.Clients
                         case "isFlaky":
                             fields.IsFlaky = result.Fields[key];
                             break;
+                        case "tags":
+                            fields.Tags = result.Fields[key];
+                            break;
                         default:
                             fields.AdditionalProperties[key] = JsonSerializer.Deserialize<JsonElement>(JsonSerializer.Serialize(result.Fields[key]));
                             break;
@@ -202,6 +205,11 @@ namespace Qase.Csharp.Commons.Clients
                 }
             }
             
+            if (result.Tags != null && result.Tags.Count > 0)
+            {
+                fields.Tags = string.Join(",", result.Tags.Distinct());
+            }
+
             var paramGroups = result.ParamGroups?.Select(g => g.Select(p => p.ToString()).ToList()).ToList();
             
             var convertedResult = new ResultCreate(

--- a/Qase.Csharp.Commons/models/domain/TestResult.cs
+++ b/Qase.Csharp.Commons/models/domain/TestResult.cs
@@ -72,6 +72,11 @@ namespace Qase.Csharp.Commons.Models.Domain
         public Relations? Relations { get; set; }
 
         /// <summary>
+        /// Gets or sets the tags
+        /// </summary>
+        public List<string> Tags { get; set; } = new();
+
+        /// <summary>
         /// Gets or sets whether the test is muted
         /// </summary>
         public bool Muted { get; set; }

--- a/Qase.Reqnroll.Reporter.Tests/ReqnrollTagParserTests.cs
+++ b/Qase.Reqnroll.Reporter.Tests/ReqnrollTagParserTests.cs
@@ -152,6 +152,71 @@ public class ReqnrollTagParserTests
 
     #endregion
 
+    #region QaseTags Tests
+
+    [Fact]
+    public void ParseTags_QaseTags_AddsToTags()
+    {
+        var result = new TestResult();
+        var tags = new[] { "QaseTags:smoke" };
+
+        ReqnrollTagParser.ApplyTags(result, tags);
+
+        result.Tags.Should().Contain("smoke");
+    }
+
+    [Fact]
+    public void ParseTags_MultipleQaseTags_AddsAll()
+    {
+        var result = new TestResult();
+        var tags = new[] { "QaseTags:smoke,regression,api" };
+
+        ReqnrollTagParser.ApplyTags(result, tags);
+
+        result.Tags.Should().HaveCount(3);
+        result.Tags.Should().Contain("smoke");
+        result.Tags.Should().Contain("regression");
+        result.Tags.Should().Contain("api");
+    }
+
+    [Fact]
+    public void ParseTags_QaseTagsCaseInsensitive_AddsTags()
+    {
+        var result = new TestResult();
+        var tags = new[] { "qasetags:Smoke" };
+
+        ReqnrollTagParser.ApplyTags(result, tags);
+
+        result.Tags.Should().Contain("Smoke");
+    }
+
+    [Fact]
+    public void ParseTags_QaseTagsWithSpaces_TrimsValues()
+    {
+        var result = new TestResult();
+        var tags = new[] { "QaseTags: smoke , regression " };
+
+        ReqnrollTagParser.ApplyTags(result, tags);
+
+        result.Tags.Should().Contain("smoke");
+        result.Tags.Should().Contain("regression");
+    }
+
+    [Fact]
+    public void ParseTags_MultipleQaseTagsAttributes_Accumulates()
+    {
+        var result = new TestResult();
+        var tags = new[] { "QaseTags:smoke", "QaseTags:regression" };
+
+        ReqnrollTagParser.ApplyTags(result, tags);
+
+        result.Tags.Should().HaveCount(2);
+        result.Tags.Should().Contain("smoke");
+        result.Tags.Should().Contain("regression");
+    }
+
+    #endregion
+
     #region Mixed Tags Tests
 
     [Fact]

--- a/Qase.Reqnroll.Reporter/ReqnrollTagParser.cs
+++ b/Qase.Reqnroll.Reporter/ReqnrollTagParser.cs
@@ -16,6 +16,7 @@ namespace Qase.Reqnroll.Reporter
         private const string QaseTitlePrefix = "qasetitle:";
         private const string QaseFieldsPrefix = "qasefields:";
         private const string QaseSuitePrefix = "qasesuite:";
+        private const string QaseTagsPrefix = "qasetags:";
         private const string QaseIgnoreTag = "qaseignore";
 
         /// <summary>
@@ -45,6 +46,10 @@ namespace Qase.Reqnroll.Reporter
                 else if (lower.StartsWith(QaseSuitePrefix))
                 {
                     ApplyQaseSuite(result, tag.Substring(QaseSuitePrefix.Length));
+                }
+                else if (lower.StartsWith(QaseTagsPrefix))
+                {
+                    ApplyQaseTags(result, tag.Substring(QaseTagsPrefix.Length));
                 }
                 else if (lower == QaseIgnoreTag)
                 {
@@ -89,6 +94,19 @@ namespace Qase.Reqnroll.Reporter
                 var key = value.Substring(0, colonIndex);
                 var val = value.Substring(colonIndex + 1);
                 result.Fields[key] = val;
+            }
+        }
+
+        private static void ApplyQaseTags(TestResult result, string value)
+        {
+            var tags = value.Split(',');
+            foreach (var tag in tags)
+            {
+                var trimmed = tag.Trim();
+                if (!string.IsNullOrEmpty(trimmed))
+                {
+                    result.Tags.Add(trimmed);
+                }
             }
         }
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## qase-csharp 1.1.15
+
+- Added `[Tags]` attribute for assigning tags to test cases from test code
+- Tags support on both class and method levels with merge semantics (class + method tags are combined)
+- Added `@QaseTags:tag1,tag2` Gherkin tag support for Reqnroll reporter
+- Tags are passed to Qase API v2 via `ResultCreateFields.Tags` (comma-separated)
+- Added tags to example projects for all frameworks (NUnit, xUnit, xUnit v3, MSTest, Reqnroll)
+- Updated expected YAML files for integration testing with tags validation
+
 ## qase-csharp 1.1.14
 
 - Updated API clients to the latest specification

--- a/examples/MSTestExamples/AttributeTests.cs
+++ b/examples/MSTestExamples/AttributeTests.cs
@@ -9,6 +9,7 @@ namespace MSTestExamples;
 [TestClass]
 [Fields("layer", "e2e")]
 [Suites("Authentication", "Smoke Tests")]
+[Tags("smoke")]
 public class AttributeTests
 {
     [TestMethod]
@@ -49,6 +50,7 @@ public class AttributeTests
     [Fields("severity", "critical")]
     [Fields("priority", "high")]
     [Fields("layer", "api")]
+    [Tags("regression")]
     public void PasswordReset_SendsEmailToRegisteredUser()
     {
         var email = "john.doe@example.com";

--- a/examples/NUnitExamples/AttributeTests.cs
+++ b/examples/NUnitExamples/AttributeTests.cs
@@ -9,6 +9,7 @@ namespace NUnitExamples;
 [TestFixture]
 [Fields("layer", "e2e")]
 [Suites("Authentication", "Smoke Tests")]
+[Tags("smoke")]
 public class AttributeTests
 {
     [Test]
@@ -49,6 +50,7 @@ public class AttributeTests
     [Fields("severity", "critical")]
     [Fields("priority", "high")]
     [Fields("layer", "api")]
+    [Tags("regression")]
     public void PasswordReset_SendsEmailToRegisteredUser()
     {
         var email = "john.doe@example.com";

--- a/examples/ReqnrollExamples/Features/TagTests.feature
+++ b/examples/ReqnrollExamples/Features/TagTests.feature
@@ -3,6 +3,7 @@
 
 @QaseFields:layer:e2e
 @QaseSuite:Authentication\Smoke_Tests
+@QaseTags:smoke
 Feature: Tag Tests
 
   @QaseId:101
@@ -29,6 +30,7 @@ Feature: Tag Tests
   @QaseFields:severity:critical
   @QaseFields:priority:high
   @QaseFields:layer:api
+  @QaseTags:regression
   Scenario: Password reset sends email to registered user
     Given a registered user "john.doe@example.com"
     When a password reset is requested

--- a/examples/xUnitExamples/AttributeTests.cs
+++ b/examples/xUnitExamples/AttributeTests.cs
@@ -8,6 +8,7 @@ namespace xUnitExamples;
 /// </summary>
 [Fields("layer", "e2e")]
 [Suites("Authentication", "Smoke Tests")]
+[Tags("smoke")]
 public class AttributeTests
 {
     [Fact]
@@ -48,6 +49,7 @@ public class AttributeTests
     [Fields("severity", "critical")]
     [Fields("priority", "high")]
     [Fields("layer", "api")]
+    [Tags("regression")]
     public void PasswordReset_SendsEmailToRegisteredUser()
     {
         var email = "john.doe@example.com";

--- a/examples/xUnitV3Examples/AttributeTests.cs
+++ b/examples/xUnitV3Examples/AttributeTests.cs
@@ -8,6 +8,7 @@ namespace xUnitV3Examples;
 /// </summary>
 [Fields("layer", "e2e")]
 [Suites("Authentication", "Smoke Tests")]
+[Tags("smoke")]
 public class AttributeTests
 {
     [Fact]
@@ -48,6 +49,7 @@ public class AttributeTests
     [Fields("severity", "critical")]
     [Fields("priority", "high")]
     [Fields("layer", "api")]
+    [Tags("regression")]
     public void PasswordReset_SendsEmailToRegisteredUser()
     {
         var email = "john.doe@example.com";

--- a/expected/mstest-examples.yaml
+++ b/expected/mstest-examples.yaml
@@ -29,6 +29,8 @@ results:
   status: passed
   fields:
     layer: e2e
+  tags:
+  - smoke
   relations:
     suite:
       data:
@@ -139,6 +141,8 @@ results:
   status: passed
   fields:
     layer: e2e
+  tags:
+  - smoke
   relations:
     suite:
       data:
@@ -283,6 +287,9 @@ results:
     layer: api
     severity: critical
     priority: high
+  tags:
+  - smoke
+  - regression
   relations:
     suite:
       data:
@@ -447,6 +454,8 @@ results:
   status: passed
   fields:
     layer: e2e
+  tags:
+  - smoke
   relations:
     suite:
       data:
@@ -530,6 +539,8 @@ results:
   status: passed
   fields:
     layer: e2e
+  tags:
+  - smoke
   relations:
     suite:
       data:

--- a/expected/nunit-examples.yaml
+++ b/expected/nunit-examples.yaml
@@ -29,6 +29,8 @@ results:
   status: passed
   fields:
     layer: e2e
+  tags:
+  - smoke
   relations:
     suite:
       data:
@@ -183,6 +185,9 @@ results:
     layer: api
     severity: critical
     priority: high
+  tags:
+  - smoke
+  - regression
   relations:
     suite:
       data:
@@ -233,6 +238,8 @@ results:
   status: passed
   fields:
     layer: e2e
+  tags:
+  - smoke
   relations:
     suite:
       data:
@@ -389,6 +396,8 @@ results:
   status: passed
   fields:
     layer: e2e
+  tags:
+  - smoke
   relations:
     suite:
       data:
@@ -599,6 +608,8 @@ results:
   status: passed
   fields:
     layer: e2e
+  tags:
+  - smoke
   relations:
     suite:
       data:

--- a/expected/reqnroll-examples.yaml
+++ b/expected/reqnroll-examples.yaml
@@ -16,6 +16,8 @@ results:
   status: passed
   fields:
     layer: e2e
+  tags:
+  - smoke
   relations:
     suite:
       data:
@@ -155,6 +157,8 @@ results:
   status: passed
   fields:
     layer: e2e
+  tags:
+  - smoke
   relations:
     suite:
       data:
@@ -518,6 +522,8 @@ results:
   status: passed
   fields:
     layer: e2e
+  tags:
+  - smoke
   relations:
     suite:
       data:
@@ -709,6 +715,8 @@ results:
   status: passed
   fields:
     layer: e2e
+  tags:
+  - smoke
   relations:
     suite:
       data:
@@ -736,6 +744,9 @@ results:
     severity: critical
     priority: high
     layer: e2e
+  tags:
+  - regression
+  - smoke
   relations:
     suite:
       data:

--- a/expected/xunit-examples.yaml
+++ b/expected/xunit-examples.yaml
@@ -42,6 +42,8 @@ results:
   status: passed
   fields:
     layer: e2e
+  tags:
+  - smoke
   relations:
     suite:
       data:
@@ -82,6 +84,8 @@ results:
   status: passed
   fields:
     layer: e2e
+  tags:
+  - smoke
   relations:
     suite:
       data:
@@ -185,6 +189,8 @@ results:
   status: passed
   fields:
     layer: e2e
+  tags:
+  - smoke
   relations:
     suite:
       data:
@@ -280,6 +286,8 @@ results:
   status: passed
   fields:
     layer: e2e
+  tags:
+  - smoke
   relations:
     suite:
       data:
@@ -503,6 +511,9 @@ results:
     layer: api
     severity: critical
     priority: high
+  tags:
+  - smoke
+  - regression
   relations:
     suite:
       data:

--- a/expected/xunit-v3-examples.yaml
+++ b/expected/xunit-v3-examples.yaml
@@ -95,6 +95,8 @@ results:
   status: passed
   fields:
     layer: e2e
+  tags:
+  - smoke
   relations:
     suite:
       data:
@@ -139,6 +141,8 @@ results:
   status: passed
   fields:
     layer: e2e
+  tags:
+  - smoke
   relations:
     suite:
       data:
@@ -151,6 +155,8 @@ results:
   status: passed
   fields:
     layer: e2e
+  tags:
+  - smoke
   relations:
     suite:
       data:
@@ -311,6 +317,9 @@ results:
     layer: api
     severity: critical
     priority: high
+  tags:
+  - smoke
+  - regression
   relations:
     suite:
       data:
@@ -520,6 +529,8 @@ results:
   status: passed
   fields:
     layer: e2e
+  tags:
+  - smoke
   relations:
     suite:
       data:


### PR DESCRIPTION
## Summary

- Added `[Tags("smoke", "regression")]` attribute for assigning tags to test cases from C# test code
- Tags on class and method levels are **merged** (not overwritten) — class tags + method tags combined
- Added `@QaseTags:tag1,tag2` Gherkin tag support for Reqnroll reporter
- Tags mapped to `ResultCreateFields.Tags` as comma-separated string for Qase API v2
- Bumped version to `1.1.15`

### Files changed

| Area | Files |
|------|-------|
| Core | `TagsAttribute.cs`, `TestResult.cs`, `AttributeExtractor.cs`, `ClientV2.cs` |
| Reqnroll | `ReqnrollTagParser.cs` |
| Examples | `AttributeTests.cs` (x4), `TagTests.feature` |
| Expected | `*-examples.yaml` (x5) |
| Tests | `AttributeExtractorTests.cs`, `TestFixtures.cs`, `ReqnrollTagParserTests.cs` |
| Meta | `Directory.Build.props`, `changelog.md` |

### Verified

- Tested in testops mode against DEVX project (run 580) — tags correctly sent to API
- All 618 unit tests pass
- `TagsOption.Value = "smoke,regression"` confirmed in API request logs

## Test plan

- [x] Unit tests for `TagsAttribute` extraction (class, method, merge)
- [x] Unit tests for `@QaseTags` parsing in Reqnroll
- [x] Build passes with 0 errors
- [x] All existing tests still pass (618 total)
- [x] E2E: MSTest examples in testops mode — tags visible in Qase run 580