### PR TITLE
docs: add Tags attribute usage to all reporter docs

### DIFF
--- a/Qase.MSTest.Reporter/docs/usage.md
+++ b/Qase.MSTest.Reporter/docs/usage.md
@@ -6,6 +6,7 @@
 - [Configuration](#configuration)
 - [Linking Test Cases](#linking-test-cases)
 - [Test Metadata](#test-metadata)
+- [Tags](#tags)
 - [Test Steps](#test-steps)
 - [Attachments](#attachments)
 - [Parameters](#parameters)
@@ -186,6 +187,53 @@ public void TestInSuite()
 }
 ```
 
+### Tags
+
+Assign tags to your test cases. Tags are used for categorization and filtering in Qase:
+
+```csharp
+[TestMethod]
+[Tags("smoke", "auth")]
+public void QuickLoginCheck()
+{
+    // Test implementation
+}
+```
+
+Multiple `[Tags]` attributes can be combined:
+
+```csharp
+[TestMethod]
+[Tags("smoke")]
+[Tags("regression")]
+public void LoginWithValidCredentials()
+{
+    // Test implementation
+}
+```
+
+Tags support class-level application. Class and method tags are **merged** (not overwritten):
+
+```csharp
+[TestClass]
+[Tags("smoke")]
+public class LoginTests
+{
+    [TestMethod]
+    [Tags("regression")]
+    public void LoginTest()
+    {
+        // This test will have tags: ["smoke", "regression"]
+    }
+
+    [TestMethod]
+    public void LogoutTest()
+    {
+        // This test will have tags: ["smoke"]
+    }
+}
+```
+
 ### Class-Level Attributes
 
 Apply attributes at the class level to affect all tests in the class:
@@ -197,13 +245,14 @@ using Qase.Csharp.Commons.Attributes;
 [TestClass]
 [Suites("API", "User Management")]
 [Fields("component", "user-api")]
+[Tags("smoke")]
 public class UserApiTests
 {
     [TestMethod]
     [Title("Create User with Valid Data")]
     public void CreateUser()
     {
-        // Inherits Suites and Fields from class level
+        // Inherits Suites, Fields, and Tags from class level
     }
 
     [TestMethod]
@@ -211,7 +260,7 @@ public class UserApiTests
     [Suites("API", "User Management", "Deletion")]
     public void DeleteUser()
     {
-        // Overrides Suites, inherits Fields from class level
+        // Overrides Suites, inherits Fields and Tags from class level
     }
 }
 ```
@@ -225,6 +274,7 @@ public class UserApiTests
 [Fields("priority", "high")]
 [Fields("component", "User API")]
 [Suites("API", "User Management", "Creation")]
+[Tags("smoke")]
 public void CreateUser_WithValidData_ShouldSucceed()
 {
     // Test implementation

--- a/Qase.NUnit.Reporter/docs/usage.md
+++ b/Qase.NUnit.Reporter/docs/usage.md
@@ -6,6 +6,7 @@
 - [Configuration](#configuration)
 - [Linking Test Cases](#linking-test-cases)
 - [Test Metadata](#test-metadata)
+- [Tags](#tags)
 - [Test Steps](#test-steps)
 - [Attachments](#attachments)
 - [Parameters](#parameters)
@@ -186,6 +187,53 @@ public void TestInSuite()
 }
 ```
 
+### Tags
+
+Assign tags to your test cases. Tags are used for categorization and filtering in Qase:
+
+```csharp
+[Test]
+[Tags("smoke", "auth")]
+public void QuickLoginCheck()
+{
+    // Test implementation
+}
+```
+
+Multiple `[Tags]` attributes can be combined:
+
+```csharp
+[Test]
+[Tags("smoke")]
+[Tags("regression")]
+public void LoginWithValidCredentials()
+{
+    // Test implementation
+}
+```
+
+Tags support class-level application. Class and method tags are **merged** (not overwritten):
+
+```csharp
+[TestFixture]
+[Tags("smoke")]
+public class LoginTests
+{
+    [Test]
+    [Tags("regression")]
+    public void LoginTest()
+    {
+        // This test will have tags: ["smoke", "regression"]
+    }
+
+    [Test]
+    public void LogoutTest()
+    {
+        // This test will have tags: ["smoke"]
+    }
+}
+```
+
 ### Class-Level Attributes
 
 Apply attributes at the class level to affect all tests in the class:
@@ -197,13 +245,14 @@ using Qase.Csharp.Commons.Attributes;
 [TestFixture]
 [Suites("API", "User Management")]
 [Fields("component", "user-api")]
+[Tags("smoke")]
 public class UserApiTests
 {
     [Test]
     [Title("Create User with Valid Data")]
     public void CreateUser()
     {
-        // Inherits Suites and Fields from class level
+        // Inherits Suites, Fields, and Tags from class level
     }
 
     [Test]
@@ -211,7 +260,7 @@ public class UserApiTests
     [Suites("API", "User Management", "Deletion")]
     public void DeleteUser()
     {
-        // Overrides Suites, inherits Fields from class level
+        // Overrides Suites, inherits Fields and Tags from class level
     }
 }
 ```
@@ -225,6 +274,7 @@ public class UserApiTests
 [Fields("priority", "high")]
 [Fields("component", "User API")]
 [Suites("API", "User Management", "Creation")]
+[Tags("smoke")]
 public void CreateUser_WithValidData_ShouldSucceed()
 {
     // Test implementation

--- a/Qase.Reqnroll.Reporter/docs/usage.md
+++ b/Qase.Reqnroll.Reporter/docs/usage.md
@@ -6,6 +6,7 @@
 - [Configuration](#configuration)
 - [Linking Test Cases](#linking-test-cases)
 - [Test Metadata](#test-metadata)
+- [Tags](#tags)
 - [Test Steps](#test-steps)
 - [Attachments](#attachments)
 - [Parameters](#parameters)
@@ -197,6 +198,39 @@ This creates the suite hierarchy: API > Authentication > Login.
 
 By default, the Feature name is used as the suite. The `@QaseSuite` tag overrides this behavior.
 
+### Tags
+
+Assign tags to your test cases using `@QaseTags`:
+
+```gherkin
+@QaseTags:smoke,regression
+Scenario: User can log in
+  Given the login page is open
+  When the user enters valid credentials
+  Then the dashboard should be displayed
+```
+
+Feature-level and scenario-level tags are **merged** (not overwritten):
+
+```gherkin
+@QaseTags:smoke
+Feature: Login
+
+  @QaseTags:regression
+  Scenario: Login with valid credentials
+    # This scenario will have tags: ["regression", "smoke"]
+    Given the login page is open
+    When the user enters valid credentials
+    Then the dashboard should be displayed
+
+  Scenario: Login page displays correctly
+    # This scenario will have tags: ["smoke"]
+    Given the login page is open
+    Then the page title should be correct
+```
+
+> **Note**: Scenario-level tags appear before feature-level tags in the combined list.
+
 ### Feature-Level Tags
 
 Tags placed at the Feature level apply to all scenarios in the file:
@@ -231,6 +265,7 @@ Both scenarios inherit `@QaseFields:component:user-api` and `@QaseSuite:API\User
 @QaseFields:priority:high
 @QaseFields:component:User_API
 @QaseSuite:API\User_Management\Creation
+@QaseTags:smoke
 Scenario: Create user with valid data should succeed
   Given the API is available
   When a new user is created with valid data

--- a/Qase.XUnit.Reporter/docs/usage.md
+++ b/Qase.XUnit.Reporter/docs/usage.md
@@ -6,6 +6,7 @@
 - [Configuration](#configuration)
 - [Linking Test Cases](#linking-test-cases)
 - [Test Metadata](#test-metadata)
+- [Tags](#tags)
 - [Test Steps](#test-steps)
 - [Attachments](#attachments)
 - [Parameters](#parameters)
@@ -185,6 +186,52 @@ public void TestInSuite()
 }
 ```
 
+### Tags
+
+Assign tags to your test cases. Tags are used for categorization and filtering in Qase:
+
+```csharp
+[Fact]
+[Tags("smoke", "auth")]
+public void QuickLoginCheck()
+{
+    // Test implementation
+}
+```
+
+Multiple `[Tags]` attributes can be combined:
+
+```csharp
+[Fact]
+[Tags("smoke")]
+[Tags("regression")]
+public void LoginWithValidCredentials()
+{
+    // Test implementation
+}
+```
+
+Tags support class-level application. Class and method tags are **merged** (not overwritten):
+
+```csharp
+[Tags("smoke")]
+public class LoginTests
+{
+    [Fact]
+    [Tags("regression")]
+    public void LoginTest()
+    {
+        // This test will have tags: ["smoke", "regression"]
+    }
+
+    [Fact]
+    public void LogoutTest()
+    {
+        // This test will have tags: ["smoke"]
+    }
+}
+```
+
 ### Class-Level Attributes
 
 Apply attributes at the class level to affect all tests in the class:
@@ -195,13 +242,14 @@ using Qase.Csharp.Commons.Attributes;
 
 [Suites("API", "User Management")]
 [Fields("component", "user-api")]
+[Tags("smoke")]
 public class UserApiTests
 {
     [Fact]
     [Title("Create User with Valid Data")]
     public void CreateUser()
     {
-        // Inherits Suites and Fields from class level
+        // Inherits Suites, Fields, and Tags from class level
     }
 
     [Fact]
@@ -209,7 +257,7 @@ public class UserApiTests
     [Suites("API", "User Management", "Deletion")]
     public void DeleteUser()
     {
-        // Overrides Suites, inherits Fields from class level
+        // Overrides Suites, inherits Fields and Tags from class level
     }
 }
 ```
@@ -223,6 +271,7 @@ public class UserApiTests
 [Fields("priority", "high")]
 [Fields("component", "User API")]
 [Suites("API", "User Management", "Creation")]
+[Tags("smoke")]
 public void CreateUser_WithValidData_ShouldSucceed()
 {
     // Test implementation

--- a/Qase.XUnit.V3.Reporter/docs/usage.md
+++ b/Qase.XUnit.V3.Reporter/docs/usage.md
@@ -7,6 +7,7 @@
 - [Project Setup](#project-setup)
 - [Linking Test Cases](#linking-test-cases)
 - [Test Metadata](#test-metadata)
+- [Tags](#tags)
 - [Test Steps](#test-steps)
 - [Attachments](#attachments)
 - [Parameters](#parameters)
@@ -225,6 +226,52 @@ public void TestInSuite()
 }
 ```
 
+### Tags
+
+Assign tags to your test cases. Tags are used for categorization and filtering in Qase:
+
+```csharp
+[Fact]
+[Tags("smoke", "auth")]
+public void QuickLoginCheck()
+{
+    // Test implementation
+}
+```
+
+Multiple `[Tags]` attributes can be combined:
+
+```csharp
+[Fact]
+[Tags("smoke")]
+[Tags("regression")]
+public void LoginWithValidCredentials()
+{
+    // Test implementation
+}
+```
+
+Tags support class-level application. Class and method tags are **merged** (not overwritten):
+
+```csharp
+[Tags("smoke")]
+public class LoginTests
+{
+    [Fact]
+    [Tags("regression")]
+    public void LoginTest()
+    {
+        // This test will have tags: ["smoke", "regression"]
+    }
+
+    [Fact]
+    public void LogoutTest()
+    {
+        // This test will have tags: ["smoke"]
+    }
+}
+```
+
 ### Class-Level Attributes
 
 Apply attributes at the class level to affect all tests in the class:
@@ -235,13 +282,14 @@ using Qase.Csharp.Commons.Attributes;
 
 [Suites("API", "User Management")]
 [Fields("component", "user-api")]
+[Tags("smoke")]
 public class UserApiTests
 {
     [Fact]
     [Title("Create User with Valid Data")]
     public void CreateUser()
     {
-        // Inherits Suites and Fields from class level
+        // Inherits Suites, Fields, and Tags from class level
     }
 
     [Fact]
@@ -249,7 +297,7 @@ public class UserApiTests
     [Suites("API", "User Management", "Deletion")]
     public void DeleteUser()
     {
-        // Overrides Suites, inherits Fields from class level
+        // Overrides Suites, inherits Fields and Tags from class level
     }
 }
 ```
@@ -263,6 +311,7 @@ public class UserApiTests
 [Fields("priority", "high")]
 [Fields("component", "User API")]
 [Suites("API", "User Management", "Creation")]
+[Tags("smoke")]
 public void CreateUser_WithValidData_ShouldSucceed()
 {
     // Test implementation


### PR DESCRIPTION
## Summary

- Added `### Tags` section to `usage.md` for all 5 reporters (MSTest, NUnit, xUnit, xUnit V3, Reqnroll)
- Documented basic usage, multiple `[Tags]` attributes, and class+method merge semantics
- Reqnroll: documented `@QaseTags:tag1,tag2` with feature/scenario merge note
- Updated Combined Metadata and Class-Level Attributes examples to include Tags

## Test plan

- [x] Docs-only change, no code modified
- [x] Review formatting in each `usage.md`