### PR TITLE
fix: detect all reporter types in HostInfo

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   <!-- Metadata -->
   <PropertyGroup>
-    <Version>1.1.15</Version>
+    <Version>1.1.16</Version>
     <Copyright>Copyright (c) 2025 Qase</Copyright>
     <Authors>Qase Team</Authors>
     <Company>qase.io</Company>

--- a/Qase.Csharp.Commons/core/HostInfo.cs
+++ b/Qase.Csharp.Commons/core/HostInfo.cs
@@ -309,18 +309,24 @@ namespace Qase.Csharp.Commons.Core
             {
                 var assemblies = AppDomain.CurrentDomain.GetAssemblies();
 
-                // Check for Qase.XUnit.Reporter
-                var xunitReporterAssembly = assemblies.FirstOrDefault(a => 
-                    a.GetName().Name == "Qase.XUnit.Reporters" || 
-                    a.GetName().Name == "Qase.XUnit.Reporter");
-                
-                if (xunitReporterAssembly != null)
+                var reporters = new (string assemblyName, string reporterName)[]
                 {
-                    var version = xunitReporterAssembly.GetName().Version?.ToString();
-                    return ("qase-xunit", version);
-                }
+                    ("Qase.XUnit.V3.Reporter", "qase-xunitv3"),
+                    ("Qase.XUnit.Reporters", "qase-xunit"),
+                    ("Qase.NUnit.Reporter", "qase-nunit"),
+                    ("Qase.MSTest.Reporter", "qase-mstest"),
+                    ("Qase.ReqnrollPlugin", "qase-reqnroll"),
+                };
 
-                // Add more reporter detection logic here as needed
+                foreach (var (assemblyName, reporterName) in reporters)
+                {
+                    var assembly = assemblies.FirstOrDefault(a => a.GetName().Name == assemblyName);
+                    if (assembly != null)
+                    {
+                        var version = assembly.GetName().Version?.ToString();
+                        return (reporterName, version);
+                    }
+                }
             }
             catch
             {


### PR DESCRIPTION
## Summary
- `DetectReporter()` previously only detected the xUnit reporter. Now detects all 5 reporters: xUnit v2, xUnit v3, NUnit, MSTest, and Reqnroll
- Bumped patch version to 1.1.16

## Changes
| Assembly | Reporter name |
|---|---|
| `Qase.XUnit.V3.Reporter` | `qase-xunitv3` |
| `Qase.XUnit.Reporters` | `qase-xunit` |
| `Qase.NUnit.Reporter` | `qase-nunit` |
| `Qase.MSTest.Reporter` | `qase-mstest` |
| `Qase.ReqnrollPlugin` | `qase-reqnroll` |

## Test plan
- [x] Verify each reporter is correctly detected when its assembly is loaded
- [x] Verify version is correctly extracted for each reporter