### PR TITLE
fix: improve API error logging with full response details

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   <!-- Metadata -->
   <PropertyGroup>
-    <Version>1.1.16</Version>
+    <Version>1.1.17</Version>
     <Copyright>Copyright (c) 2025 Qase</Copyright>
     <Authors>Qase Team</Authors>
     <Company>qase.io</Company>

--- a/Qase.Csharp.Commons/clients/ClientV1.cs
+++ b/Qase.Csharp.Commons/clients/ClientV1.cs
@@ -95,7 +95,9 @@ namespace Qase.Csharp.Commons.Clients
                 }
                 else
                 {
-                    throw new QaseException($"Failed to create test run: {resp.ReasonPhrase}");
+                    _logger.LogError("Failed to create test run. StatusCode={StatusCode}, Reason={Reason}, Response={Response}",
+                        resp.StatusCode, resp.ReasonPhrase, resp.RawContent);
+                    throw new QaseException($"Failed to create test run: {resp.ReasonPhrase}. Response: {resp.RawContent}");
                 }
             }
             catch (Exception ex) when (!(ex is QaseException))
@@ -120,7 +122,9 @@ namespace Qase.Csharp.Commons.Clients
                 }
                 else
                 {
-                    throw new QaseException($"Failed to complete test run: {resp.ReasonPhrase}");
+                    _logger.LogError("Failed to complete test run. StatusCode={StatusCode}, Reason={Reason}, Response={Response}",
+                        resp.StatusCode, resp.ReasonPhrase, resp.RawContent);
+                    throw new QaseException($"Failed to complete test run: {resp.ReasonPhrase}. Response: {resp.RawContent}");
                 }
             }
             catch (Exception ex) when (!(ex is QaseException))
@@ -156,7 +160,9 @@ namespace Qase.Csharp.Commons.Clients
                 }
                 else
                 {
-                    throw new QaseException($"Failed to get test case ids for execution: {resp.ReasonPhrase}");
+                    _logger.LogError("Failed to get test case ids for execution. StatusCode={StatusCode}, Reason={Reason}, Response={Response}",
+                        resp.StatusCode, resp.ReasonPhrase, resp.RawContent);
+                    throw new QaseException($"Failed to get test case ids for execution: {resp.ReasonPhrase}. Response: {resp.RawContent}");
                 }
             }
             catch (Exception ex) when (!(ex is QaseException))
@@ -223,8 +229,9 @@ namespace Qase.Csharp.Commons.Clients
                     }
                     else
                     {
-                        _logger.LogError("Failed to upload attachment batch: {Reason}", resp.ReasonPhrase + " " + resp.RawContent);
-                        throw new QaseException($"Failed to upload attachments: {resp.ReasonPhrase}");
+                        _logger.LogError("Failed to upload attachment batch. StatusCode={StatusCode}, Reason={Reason}, Response={Response}",
+                            resp.StatusCode, resp.ReasonPhrase, resp.RawContent);
+                        throw new QaseException($"Failed to upload attachments: {resp.ReasonPhrase}. Response: {resp.RawContent}");
                     }
                 }
 
@@ -409,7 +416,8 @@ namespace Qase.Csharp.Commons.Clients
                 var resp = await _configurationsApi.GetConfigurationsAsync(_config.TestOps.Project!);
                 if (!resp.IsSuccessStatusCode)
                 {
-                    _logger.LogWarning("Failed to get configurations: {Reason}", resp.ReasonPhrase);
+                    _logger.LogWarning("Failed to get configurations. StatusCode={StatusCode}, Reason={Reason}, Response={Response}",
+                        resp.StatusCode, resp.ReasonPhrase, resp.RawContent);
                     return new List<long>();
                 }
 
@@ -506,7 +514,9 @@ namespace Qase.Csharp.Commons.Clients
                 }
                 else
                 {
-                    throw new QaseException($"Failed to enable public report: {resp.ReasonPhrase}");
+                    _logger.LogError("Failed to enable public report. StatusCode={StatusCode}, Reason={Reason}, Response={Response}",
+                        resp.StatusCode, resp.ReasonPhrase, resp.RawContent);
+                    throw new QaseException($"Failed to enable public report: {resp.ReasonPhrase}. Response: {resp.RawContent}");
                 }
             }
             catch (Exception ex) when (!(ex is QaseException))
@@ -546,7 +556,8 @@ namespace Qase.Csharp.Commons.Clients
                 }
                 else
                 {
-                    _logger.LogWarning("Failed to attach external link to run {RunId}: {ReasonPhrase}", runId, resp.ReasonPhrase);
+                    _logger.LogWarning("Failed to attach external link to run {RunId}. StatusCode={StatusCode}, Reason={Reason}, Response={Response}",
+                        runId, resp.StatusCode, resp.ReasonPhrase, resp.RawContent);
                 }
             }
             catch (Exception ex)

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## qase-csharp 1.1.17
+
+- Improved API error logging across all V1 API calls — error responses now include HTTP status code and full response body with detailed error messages from the Qase API, making it much easier to diagnose issues like invalid environment slugs, missing projects, or authentication problems
+
+## qase-csharp 1.1.16
+
+- Fixed detection of all reporter types in HostInfo
+- Added Tags attribute usage documentation to all reporter docs
+
 ## qase-csharp 1.1.15
 
 - Added `[Tags]` attribute for assigning tags to test cases from test code


### PR DESCRIPTION
## Summary
- Improved API error logging in all V1 API calls — error responses now include HTTP status code and full response body (`RawContent`) with detailed error messages from the Qase API
- Previously only the generic HTTP reason phrase (e.g. "Bad Request") was logged, making it nearly impossible to diagnose configuration issues
- Bump version to 1.1.17

## Root cause investigated
The original issue "Failed to create test run: Bad Request" was caused by an `environment_slug` in `qase.config.json` referencing an environment that doesn't exist in the Qase project. The API returns a detailed error:
```json
{"status":false,"errorMessage":"Data is invalid.","errorFields":[{"field":"environment_slug","error":"The selected environment doesn't exist."}]}
```
This detail was completely lost in the old logging — users only saw "Bad Request".

## Test plan
- [x] All 432 unit tests pass
- [x] Verified with real Qase API — invalid `environment_slug` now produces clear error message in logs
- [x] Build succeeds with no errors