### PR TITLE
fix: downgrade AspectInjector to 2.8.2 to avoid build file lock

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   <!-- Metadata -->
   <PropertyGroup>
-    <Version>1.1.19</Version>
+    <Version>1.1.20</Version>
     <Copyright>Copyright (c) 2025 Qase</Copyright>
     <Authors>Qase Team</Authors>
     <Company>qase.io</Company>

--- a/Qase.Csharp.Commons/Qase.Csharp.Commons.csproj
+++ b/Qase.Csharp.Commons/Qase.Csharp.Commons.csproj
@@ -31,7 +31,7 @@
     <PackageReference Include="Serilog.Extensions.Logging" Version="9.0.2" />
     <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
     <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
-    <PackageReference Include="AspectInjector" Version="2.9.0" />
+    <PackageReference Include="AspectInjector" Version="2.8.2" />
   </ItemGroup>
 
 </Project>

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## qase-csharp 1.1.20
+
+- Fixed build file lock that blocked rebuilds in projects referencing a Qase reporter — downgraded `AspectInjector` to 2.8.2, avoiding the MSBuild Task in 2.9.0 that held a handle on the output assembly and caused the lock during the `CreateAppHost` step ([pamidur/aspect-injector#244](https://github.com/pamidur/aspect-injector/issues/244))
+
 ## qase-csharp 1.1.19
 
 - Updated API clients to the latest specification


### PR DESCRIPTION
## Problem

Customers hit a **file lock on build/rebuild** in any project that references a Qase reporter — the build output stays locked by an MSBuild process. It reproduces in a clean, empty project with only `Qase.NUnit.Reporter` referenced and no tests.

## Root cause

`AspectInjector 2.9.0` switched aspect weaving to an **MSBuild Task** that holds a handle on the output assembly. That handle causes a file lock during the `CreateAppHost` step (upstream [pamidur/aspect-injector#244](https://github.com/pamidur/aspect-injector/issues/244), currently unresolved). Because `AspectInjector` flows **transitively** from `Qase.Csharp.Commons` (our `[Aspect(Scope.Global)]` aspects must weave at the consumer's compile), the task runs during the consumer's build — which is why an empty project reproduces it.

## Why not the suggested workarounds

- **NUnit shadow copy** (`.runsettings` `ShadowCopyFiles`) — didn't help; the lock is on **build**, not test execution.
- **`-nodeReuse:false` / `MSBUILDDISABLENODEREUSE=1`** — only partially mitigates and pushes manual config onto every user.

## Fix

Downgrade `AspectInjector` to **2.8.2**, which performs post-build weaving and does not hold the lock. We only use the stable `Aspect`/`Advice`/`Argument` API, unchanged between 2.8 and 2.9, so no functionality is lost. Version `2.9.0` was originally introduced via a bulk version bump, not for any specific feature.

## Changes

- `Qase.Csharp.Commons.csproj`: `AspectInjector` 2.9.0 → 2.8.2
- `Directory.Build.props`: version 1.1.19 → 1.1.20 (single version shared by all packages)
- `changelog.md`: 1.1.20 entry

## Verification

- `Qase.Csharp.Commons` builds on 2.8.2 ✅
- Commons tests: **461/461 passed** ✅

> Note: locally on macOS arm64 the first build failed with `Killed: 9` because 2.8.x ships a **native** `osx-arm64/AspectInjector` binary that macOS killed as unsigned; ad-hoc signing it locally resolved it. This does not affect CI/Windows, and the customer already confirmed 2.8.2 fixes the lock.

## Follow-up

Track upstream #244 — once a fixed 2.9.x ships, we can move back to the new weaving path.