### PR TITLE
chore: update API clients to latest specification

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   <!-- Metadata -->
   <PropertyGroup>
-    <Version>1.1.24</Version>
+    <Version>1.1.25</Version>
     <Copyright>Copyright (c) 2025 Qase</Copyright>
     <Authors>Qase Team</Authors>
     <Company>qase.io</Company>

--- a/Qase.ApiClient.V1/Api/ResultsApi.cs
+++ b/Qase.ApiClient.V1/Api/ResultsApi.cs
@@ -68,7 +68,7 @@ namespace Qase.ApiClient.V1.Api
         /// Bulk create test run result
         /// </summary>
         /// <remarks>
-        /// This method allows to create a lot of test run result at once.  If you try to send more than 2,000 results in a single bulk request, you will receive an error with code 413 - Payload Too Large.  If there is no free space left in your team account, when attempting to upload an attachment, e.g., through reporters, you will receive an error with code 507 - Insufficient Storage. 
+        /// This method allows to create a lot of test run result at once.  If you try to send more than 200 results in a single bulk request, you will receive an error with code 413 - Payload Too Large.  If there is no free space left in your team account, when attempting to upload an attachment, e.g., through reporters, you will receive an error with code 507 - Insufficient Storage. 
         /// </remarks>
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
         /// <param name="code">Code of project, where to search entities.</param>
@@ -82,7 +82,7 @@ namespace Qase.ApiClient.V1.Api
         /// Bulk create test run result
         /// </summary>
         /// <remarks>
-        /// This method allows to create a lot of test run result at once.  If you try to send more than 2,000 results in a single bulk request, you will receive an error with code 413 - Payload Too Large.  If there is no free space left in your team account, when attempting to upload an attachment, e.g., through reporters, you will receive an error with code 507 - Insufficient Storage. 
+        /// This method allows to create a lot of test run result at once.  If you try to send more than 200 results in a single bulk request, you will receive an error with code 413 - Payload Too Large.  If there is no free space left in your team account, when attempting to upload an attachment, e.g., through reporters, you will receive an error with code 507 - Insufficient Storage. 
         /// </remarks>
         /// <param name="code">Code of project, where to search entities.</param>
         /// <param name="id">Identifier.</param>
@@ -1051,7 +1051,7 @@ namespace Qase.ApiClient.V1.Api
         partial void OnErrorCreateResultBulk(ref bool suppressDefaultLogLocalVar, Exception exceptionLocalVar, string pathFormatLocalVar, string pathLocalVar, string code, int id, ResultCreateBulk resultCreateBulk);
 
         /// <summary>
-        /// Bulk create test run result This method allows to create a lot of test run result at once.  If you try to send more than 2,000 results in a single bulk request, you will receive an error with code 413 - Payload Too Large.  If there is no free space left in your team account, when attempting to upload an attachment, e.g., through reporters, you will receive an error with code 507 - Insufficient Storage. 
+        /// Bulk create test run result This method allows to create a lot of test run result at once.  If you try to send more than 200 results in a single bulk request, you will receive an error with code 413 - Payload Too Large.  If there is no free space left in your team account, when attempting to upload an attachment, e.g., through reporters, you will receive an error with code 507 - Insufficient Storage. 
         /// </summary>
         /// <param name="code">Code of project, where to search entities.</param>
         /// <param name="id">Identifier.</param>
@@ -1071,7 +1071,7 @@ namespace Qase.ApiClient.V1.Api
         }
 
         /// <summary>
-        /// Bulk create test run result This method allows to create a lot of test run result at once.  If you try to send more than 2,000 results in a single bulk request, you will receive an error with code 413 - Payload Too Large.  If there is no free space left in your team account, when attempting to upload an attachment, e.g., through reporters, you will receive an error with code 507 - Insufficient Storage. 
+        /// Bulk create test run result This method allows to create a lot of test run result at once.  If you try to send more than 200 results in a single bulk request, you will receive an error with code 413 - Payload Too Large.  If there is no free space left in your team account, when attempting to upload an attachment, e.g., through reporters, you will receive an error with code 507 - Insufficient Storage. 
         /// </summary>
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
         /// <param name="code">Code of project, where to search entities.</param>

--- a/Qase.ApiClient.V1/docs/apis/ResultsApi.md
+++ b/Qase.ApiClient.V1/docs/apis/ResultsApi.md
@@ -61,7 +61,7 @@ This method allows to create test run result by Run Id.
 
 Bulk create test run result
 
-This method allows to create a lot of test run result at once.  If you try to send more than 2,000 results in a single bulk request, you will receive an error with code 413 - Payload Too Large.  If there is no free space left in your team account, when attempting to upload an attachment, e.g., through reporters, you will receive an error with code 507 - Insufficient Storage. 
+This method allows to create a lot of test run result at once.  If you try to send more than 200 results in a single bulk request, you will receive an error with code 413 - Payload Too Large.  If there is no free space left in your team account, when attempting to upload an attachment, e.g., through reporters, you will receive an error with code 507 - Insufficient Storage. 
 
 
 ### Parameters

--- a/Qase.ApiClient.V2/Api/ResultsApi.cs
+++ b/Qase.ApiClient.V2/Api/ResultsApi.cs
@@ -170,6 +170,12 @@ namespace Qase.ApiClient.V2.Api
         bool IsNotFound { get; }
 
         /// <summary>
+        /// Returns true if the response is 413 ContentTooLarge
+        /// </summary>
+        /// <returns></returns>
+        bool IsContentTooLarge { get; }
+
+        /// <summary>
         /// Returns true if the response is 422 UnprocessableContent
         /// </summary>
         /// <returns></returns>
@@ -871,6 +877,12 @@ namespace Qase.ApiClient.V2.Api
             /// </summary>
             /// <returns></returns>
             public bool IsNotFound => 404 == (int)StatusCode;
+
+            /// <summary>
+            /// Returns true if the response is 413 ContentTooLarge
+            /// </summary>
+            /// <returns></returns>
+            public bool IsContentTooLarge => 413 == (int)StatusCode;
 
             /// <summary>
             /// Returns true if the response is 422 UnprocessableContent

--- a/Qase.ApiClient.V2/Model/ResultExecution.cs
+++ b/Qase.ApiClient.V2/Model/ResultExecution.cs
@@ -39,15 +39,17 @@ namespace Qase.ApiClient.V2.Model
         /// <param name="endTime">Unix epoch time in seconds (whole part) and milliseconds (fractional part).</param>
         /// <param name="duration">Duration of the test execution in milliseconds.</param>
         /// <param name="stacktrace">stacktrace</param>
+        /// <param name="errorContext">Free-form failure context captured by the reporter. For Playwright this is the content of error-context.md (test info, error details, page snapshot), so it may include rendered page content. Stored verbatim so it can be copied as raw text. Values longer than 262144 characters are silently truncated by Qase and the request still succeeds. Write-only — not returned by the result read endpoints.</param>
         /// <param name="thread">thread</param>
         [JsonConstructor]
-        public ResultExecution(string status, Option<double?> startTime = default, Option<double?> endTime = default, Option<long?> duration = default, Option<string?> stacktrace = default, Option<string?> thread = default)
+        public ResultExecution(string status, Option<double?> startTime = default, Option<double?> endTime = default, Option<long?> duration = default, Option<string?> stacktrace = default, Option<string?> errorContext = default, Option<string?> thread = default)
         {
             Status = status;
             StartTimeOption = startTime;
             EndTimeOption = endTime;
             DurationOption = duration;
             StacktraceOption = stacktrace;
+            ErrorContextOption = errorContext;
             ThreadOption = thread;
             OnCreated();
         }
@@ -117,6 +119,20 @@ namespace Qase.ApiClient.V2.Model
         public string? Stacktrace { get { return this.StacktraceOption; } set { this.StacktraceOption = new Option<string?>(value); } }
 
         /// <summary>
+        /// Used to track the state of ErrorContext
+        /// </summary>
+        [JsonIgnore]
+        [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        public Option<string?> ErrorContextOption { get; private set; }
+
+        /// <summary>
+        /// Free-form failure context captured by the reporter. For Playwright this is the content of error-context.md (test info, error details, page snapshot), so it may include rendered page content. Stored verbatim so it can be copied as raw text. Values longer than 262144 characters are silently truncated by Qase and the request still succeeds. Write-only — not returned by the result read endpoints.
+        /// </summary>
+        /// <value>Free-form failure context captured by the reporter. For Playwright this is the content of error-context.md (test info, error details, page snapshot), so it may include rendered page content. Stored verbatim so it can be copied as raw text. Values longer than 262144 characters are silently truncated by Qase and the request still succeeds. Write-only — not returned by the result read endpoints.</value>
+        [JsonPropertyName("error_context")]
+        public string? ErrorContext { get { return this.ErrorContextOption; } set { this.ErrorContextOption = new Option<string?>(value); } }
+
+        /// <summary>
         /// Used to track the state of Thread
         /// </summary>
         [JsonIgnore]
@@ -148,6 +164,7 @@ namespace Qase.ApiClient.V2.Model
             sb.Append("  EndTime: ").Append(EndTime).Append("\n");
             sb.Append("  Duration: ").Append(Duration).Append("\n");
             sb.Append("  Stacktrace: ").Append(Stacktrace).Append("\n");
+            sb.Append("  ErrorContext: ").Append(ErrorContext).Append("\n");
             sb.Append("  Thread: ").Append(Thread).Append("\n");
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
@@ -192,6 +209,7 @@ namespace Qase.ApiClient.V2.Model
             Option<double?> endTime = default;
             Option<long?> duration = default;
             Option<string?> stacktrace = default;
+            Option<string?> errorContext = default;
             Option<string?> thread = default;
 
             while (utf8JsonReader.Read())
@@ -224,6 +242,9 @@ namespace Qase.ApiClient.V2.Model
                         case "stacktrace":
                             stacktrace = new Option<string?>(utf8JsonReader.GetString());
                             break;
+                        case "error_context":
+                            errorContext = new Option<string?>(utf8JsonReader.GetString());
+                            break;
                         case "thread":
                             thread = new Option<string?>(utf8JsonReader.GetString());
                             break;
@@ -239,7 +260,7 @@ namespace Qase.ApiClient.V2.Model
             if (status.IsSet && status.Value == null)
                 throw new ArgumentNullException(nameof(status), "Property is not nullable for class ResultExecution.");
 
-            return new ResultExecution(status.Value!, startTime, endTime, duration, stacktrace, thread);
+            return new ResultExecution(status.Value!, startTime, endTime, duration, stacktrace, errorContext, thread);
         }
 
         /// <summary>
@@ -294,6 +315,12 @@ namespace Qase.ApiClient.V2.Model
                     writer.WriteString("stacktrace", resultExecution.Stacktrace);
                 else
                     writer.WriteNull("stacktrace");
+
+            if (resultExecution.ErrorContextOption.IsSet)
+                if (resultExecution.ErrorContextOption.Value != null)
+                    writer.WriteString("error_context", resultExecution.ErrorContext);
+                else
+                    writer.WriteNull("error_context");
 
             if (resultExecution.ThreadOption.IsSet)
                 if (resultExecution.ThreadOption.Value != null)

--- a/Qase.ApiClient.V2/docs/apis/ResultsApi.md
+++ b/Qase.ApiClient.V2/docs/apis/ResultsApi.md
@@ -89,6 +89,7 @@ This method allows to create several test run results at once.  If there is no f
 | **401** | Unauthorized |  -  |
 | **403** | Forbidden |  -  |
 | **404** | Not Found |  -  |
+| **413** | Payload Too Large. Returned when the request contains more than 200 results, or when the combined length of &#x60;execution.error_context&#x60; across the batch exceeds 4194304 characters. In both cases the whole batch is rejected — no results are created.  |  -  |
 | **422** | Unprocessable Entity |  -  |
 
 [[Back to top]](#) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to Model list]](../../README.md#documentation-for-models) [[Back to README]](../../README.md)

--- a/Qase.ApiClient.V2/docs/models/ResultExecution.md
+++ b/Qase.ApiClient.V2/docs/models/ResultExecution.md
@@ -9,6 +9,7 @@ Name | Type | Description | Notes
 **EndTime** | **double** | Unix epoch time in seconds (whole part) and milliseconds (fractional part). | [optional] 
 **Duration** | **long** | Duration of the test execution in milliseconds. | [optional] 
 **Stacktrace** | **string** |  | [optional] 
+**ErrorContext** | **string** | Free-form failure context captured by the reporter. For Playwright this is the content of error-context.md (test info, error details, page snapshot), so it may include rendered page content. Stored verbatim so it can be copied as raw text. Values longer than 262144 characters are silently truncated by Qase and the request still succeeds. Write-only — not returned by the result read endpoints. | [optional] 
 **Thread** | **string** |  | [optional] 
 
 [[Back to Model list]](../../README.md#documentation-for-models) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to README]](../../README.md)

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## qase-csharp 1.1.25
+
+- Updated API clients to the latest specification
+
 ## qase-csharp 1.1.24
 
 - Updated API clients to the latest specification


### PR DESCRIPTION
## Summary

- Updated API clients to the latest OpenAPI specification
- Version bumped: 1.1.24 → 1.1.25

### Targets updated:
- `Qase.ApiClient.V1` (v1) — bulk result batch limit lowered from 2000 to 200 in the endpoint documentation
- `Qase.ApiClient.V2` (v2) — added the `execution.error_context` field to `ResultExecution` and documented the `413 Payload Too Large` response (more than 200 results, or oversized `error_context`)

### Protected files (skipped):
- `Qase.ApiClient.V1.csproj`, `Api/AttachmentsApi.cs`
- `Qase.ApiClient.V2.csproj`, `Model/ResultStep.cs`

### Warnings:
None