### PR TITLE
feat: retry the results upload and add a request timeout

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   <!-- Metadata -->
   <PropertyGroup>
-    <Version>1.1.25</Version>
+    <Version>1.1.26</Version>
     <Copyright>Copyright (c) 2025 Qase</Copyright>
     <Authors>Qase Team</Authors>
     <Company>qase.io</Company>

--- a/Qase.Csharp.Commons.Tests/ApiConnectionConfigTests.cs
+++ b/Qase.Csharp.Commons.Tests/ApiConnectionConfigTests.cs
@@ -1,0 +1,108 @@
+using System;
+using System.IO;
+using FluentAssertions;
+using Qase.Csharp.Commons.Config;
+using Xunit;
+
+namespace Qase.Csharp.Commons.Tests
+{
+    [Collection("Config")]
+    public class ApiConnectionConfigTests : IDisposable
+    {
+        private const string ConfigFileName = "qase.config.json";
+
+        private static readonly string[] EnvVars =
+        {
+            "QASE_TESTOPS_API_TIMEOUT",
+            "QASE_TESTOPS_API_RETRIES",
+            "QASE_TESTOPS_API_RETRY_BACKOFF"
+        };
+
+        public ApiConnectionConfigTests() => Cleanup();
+
+        public void Dispose() => Cleanup();
+
+        private static void Cleanup()
+        {
+            if (File.Exists(ConfigFileName))
+            {
+                File.Delete(ConfigFileName);
+            }
+
+            foreach (var name in EnvVars)
+            {
+                Environment.SetEnvironmentVariable(name, null);
+            }
+        }
+
+        [Fact]
+        public void ApiConfig_ShouldDefaultToThirtySecondTimeoutAndThreeRetries()
+        {
+            var config = new ApiConfig();
+
+            config.Timeout.Should().Be(30);
+            config.Retries.Should().Be(3);
+            config.RetryBackoff.Should().Be(1);
+        }
+
+        [Fact]
+        public void LoadConfig_ShouldReadConnectionSettingsFromEnvironment()
+        {
+            Environment.SetEnvironmentVariable("QASE_TESTOPS_API_TIMEOUT", "45");
+            Environment.SetEnvironmentVariable("QASE_TESTOPS_API_RETRIES", "5");
+            Environment.SetEnvironmentVariable("QASE_TESTOPS_API_RETRY_BACKOFF", "2.5");
+
+            var config = ConfigFactory.LoadConfig();
+
+            config.TestOps.Api.Timeout.Should().Be(45);
+            config.TestOps.Api.Retries.Should().Be(5);
+            config.TestOps.Api.RetryBackoff.Should().Be(2.5);
+        }
+
+        [Fact]
+        public void LoadConfig_ShouldReadConnectionSettingsFromFile()
+        {
+            File.WriteAllText(ConfigFileName, @"{
+  ""testops"": {
+    ""api"": {
+      ""timeout"": 15,
+      ""retries"": 7,
+      ""retryBackoff"": 0.5
+    }
+  }
+}");
+
+            var config = ConfigFactory.LoadConfig();
+
+            config.TestOps.Api.Timeout.Should().Be(15);
+            config.TestOps.Api.Retries.Should().Be(7);
+            config.TestOps.Api.RetryBackoff.Should().Be(0.5);
+        }
+
+        [Fact]
+        public void LoadConfig_ShouldLetEnvironmentOverrideTheFile()
+        {
+            File.WriteAllText(ConfigFileName, @"{
+  ""testops"": { ""api"": { ""timeout"": 15, ""retries"": 7 } }
+}");
+            Environment.SetEnvironmentVariable("QASE_TESTOPS_API_TIMEOUT", "45");
+
+            var config = ConfigFactory.LoadConfig();
+
+            config.TestOps.Api.Timeout.Should().Be(45);
+            config.TestOps.Api.Retries.Should().Be(7);
+        }
+
+        [Fact]
+        public void LoadConfig_ShouldKeepDefaultsWhenTheEnvironmentValueIsNotANumber()
+        {
+            Environment.SetEnvironmentVariable("QASE_TESTOPS_API_TIMEOUT", "soon");
+            Environment.SetEnvironmentVariable("QASE_TESTOPS_API_RETRY_BACKOFF", "later");
+
+            var config = ConfigFactory.LoadConfig();
+
+            config.TestOps.Api.Timeout.Should().Be(30);
+            config.TestOps.Api.RetryBackoff.Should().Be(1);
+        }
+    }
+}

--- a/Qase.Csharp.Commons.Tests/QaseConfigTests.cs
+++ b/Qase.Csharp.Commons.Tests/QaseConfigTests.cs
@@ -26,6 +26,15 @@ namespace Qase.Csharp.Commons.Tests
             config.Logging.File.Should().BeFalse();
         }
 
+        [Fact]
+        public void BatchConfig_ShouldDefaultToTheDocumentedMaximumSize()
+        {
+            // A size of zero makes every result its own request, because the
+            // reporter uploads as soon as the buffer reaches the batch size.
+            new BatchConfig().Size.Should().Be(200);
+            new QaseConfig().TestOps.Batch.Size.Should().Be(200);
+        }
+
         [Theory]
         [InlineData(null, Mode.Off)]
         [InlineData("", Mode.Off)]

--- a/Qase.Csharp.Commons.Tests/QaseHttpPipelineTests.cs
+++ b/Qase.Csharp.Commons.Tests/QaseHttpPipelineTests.cs
@@ -1,0 +1,137 @@
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Qase.Csharp.Commons.Clients;
+using Qase.Csharp.Commons.Config;
+
+namespace Qase.Csharp.Commons.Tests;
+
+/// <summary>
+/// Exercises the policies through a real HttpClient pipeline, which is the only
+/// way to prove a POST body survives being sent more than once.
+/// </summary>
+public class QaseHttpPipelineTests
+{
+    private sealed class RecordingHandler : HttpMessageHandler
+    {
+        private readonly HttpStatusCode[] _statuses;
+
+        public RecordingHandler(params HttpStatusCode[] statuses) => _statuses = statuses;
+
+        public List<string> ReceivedBodies { get; } = new();
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            ReceivedBodies.Add(request.Content == null
+                ? string.Empty
+                : await request.Content.ReadAsStringAsync());
+
+            var status = _statuses[Math.Min(ReceivedBodies.Count - 1, _statuses.Length - 1)];
+            return new HttpResponseMessage(status);
+        }
+    }
+
+    private static (HttpClient Client, RecordingHandler Handler) BuildClient(
+        ApiConfig api, params HttpStatusCode[] statuses)
+    {
+        var handler = new RecordingHandler(statuses);
+        var services = new ServiceCollection();
+        services.AddHttpClient("qase")
+            .ConfigurePrimaryHttpMessageHandler(() => handler)
+            .AddQaseResultsPolicies(api, NullLogger.Instance);
+
+        var provider = services.BuildServiceProvider();
+        var client = provider.GetRequiredService<IHttpClientFactory>().CreateClient("qase");
+        client.BaseAddress = new Uri("https://api.qase.test/v2/");
+        return (client, handler);
+    }
+
+    private static ApiConfig FastConfig(int retries = 3) =>
+        new() { Timeout = 30, Retries = retries, RetryBackoff = 0.001 };
+
+    [Fact]
+    public async Task Pipeline_ShouldResendTheRequestBodyOnEveryRetry()
+    {
+        var (client, handler) = BuildClient(
+            FastConfig(), (HttpStatusCode)429, HttpStatusCode.ServiceUnavailable, HttpStatusCode.OK);
+
+        var response = await client.PostAsync("results", new StringContent("{\"results\":[]}"));
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        handler.ReceivedBodies.Should().HaveCount(3);
+        handler.ReceivedBodies.Should().AllBe("{\"results\":[]}");
+    }
+
+    [Fact]
+    public async Task Pipeline_ShouldNotResendOnAPermanentFailure()
+    {
+        var (client, handler) = BuildClient(FastConfig(), (HttpStatusCode)422);
+
+        var response = await client.PostAsync("results", new StringContent("{}"));
+
+        response.StatusCode.Should().Be((HttpStatusCode)422);
+        handler.ReceivedBodies.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public async Task Pipeline_ShouldStopAfterTheConfiguredNumberOfRetries()
+    {
+        var (client, handler) = BuildClient(FastConfig(retries: 2), HttpStatusCode.BadGateway);
+
+        var response = await client.PostAsync("results", new StringContent("{}"));
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadGateway);
+        handler.ReceivedBodies.Should().HaveCount(3);
+    }
+
+    [Fact]
+    public void Pipeline_ShouldLeaveTheOuterHttpClientTimeoutOpen()
+    {
+        // The per-attempt timeout is the Polly one. HttpClient's own timeout spans
+        // the whole retry chain, so it must not cut a Retry-After wait short.
+        var (client, _) = BuildClient(FastConfig());
+
+        client.Timeout.Should().Be(Timeout.InfiniteTimeSpan);
+    }
+
+    [Fact]
+    public async Task Pipeline_ShouldRetryAnAttemptThatStallsPastTheTimeout()
+    {
+        var attempts = 0;
+        var services = new ServiceCollection();
+        services.AddHttpClient("qase")
+            .ConfigurePrimaryHttpMessageHandler(() => new StallingHandler(() => attempts++))
+            .AddQaseResultsPolicies(
+                new ApiConfig { Timeout = 1, Retries = 1, RetryBackoff = 0.001 },
+                NullLogger.Instance);
+
+        var provider = services.BuildServiceProvider();
+        var client = provider.GetRequiredService<IHttpClientFactory>().CreateClient("qase");
+        client.BaseAddress = new Uri("https://api.qase.test/v2/");
+
+        var act = async () => await client.PostAsync("results", new StringContent("{}"));
+
+        await act.Should().ThrowAsync<Polly.Timeout.TimeoutRejectedException>();
+        attempts.Should().Be(2);
+    }
+
+    private sealed class StallingHandler : HttpMessageHandler
+    {
+        private readonly Action _onSend;
+
+        public StallingHandler(Action onSend) => _onSend = onSend;
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            _onSend();
+            await Task.Delay(TimeSpan.FromSeconds(30), cancellationToken);
+            return new HttpResponseMessage(HttpStatusCode.OK);
+        }
+    }
+}

--- a/Qase.Csharp.Commons.Tests/QaseHttpPoliciesTests.cs
+++ b/Qase.Csharp.Commons.Tests/QaseHttpPoliciesTests.cs
@@ -1,0 +1,321 @@
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Diagnostics;
+using Microsoft.Extensions.Logging.Abstractions;
+using Polly;
+using Polly.Timeout;
+using Qase.Csharp.Commons.Clients;
+
+namespace Qase.Csharp.Commons.Tests;
+
+public class QaseHttpPoliciesTests
+{
+    [Theory]
+    [InlineData(HttpStatusCode.RequestTimeout)]        // 408
+    [InlineData((HttpStatusCode)429)]                  // 429 Too Many Requests
+    [InlineData(HttpStatusCode.InternalServerError)]   // 500
+    [InlineData(HttpStatusCode.BadGateway)]            // 502
+    [InlineData(HttpStatusCode.ServiceUnavailable)]    // 503
+    [InlineData(HttpStatusCode.GatewayTimeout)]        // 504
+    public void IsRetryableStatus_ShouldRetryTransientStatuses(HttpStatusCode status)
+    {
+        QaseHttpPolicies.IsRetryableStatus(status).Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData(HttpStatusCode.BadRequest)]            // 400
+    [InlineData(HttpStatusCode.Unauthorized)]          // 401
+    [InlineData(HttpStatusCode.Forbidden)]             // 403
+    [InlineData(HttpStatusCode.NotFound)]              // 404
+    [InlineData(HttpStatusCode.RequestEntityTooLarge)] // 413
+    [InlineData((HttpStatusCode)422)]                  // 422 Unprocessable Content
+    [InlineData((HttpStatusCode)507)]                  // 507 Insufficient Storage
+    public void IsRetryableStatus_ShouldNotRetryPermanentFailures(HttpStatusCode status)
+    {
+        QaseHttpPolicies.IsRetryableStatus(status).Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData(HttpStatusCode.OK)]
+    [InlineData(HttpStatusCode.Created)]
+    [InlineData(HttpStatusCode.NoContent)]
+    public void IsRetryableStatus_ShouldNotRetrySuccessfulResponses(HttpStatusCode status)
+    {
+        QaseHttpPolicies.IsRetryableStatus(status).Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData(1, 1.0)]
+    [InlineData(2, 2.0)]
+    [InlineData(3, 4.0)]
+    [InlineData(4, 8.0)]
+    public void ComputeDelay_ShouldGrowExponentiallyFromTheBaseBackoff(int attempt, double expectedSeconds)
+    {
+        using var response = new HttpResponseMessage(HttpStatusCode.ServiceUnavailable);
+
+        var delay = QaseHttpPolicies.ComputeDelay(attempt, TimeSpan.FromSeconds(1), response);
+
+        delay.Should().Be(TimeSpan.FromSeconds(expectedSeconds));
+    }
+
+    [Fact]
+    public void ComputeDelay_ShouldScaleWithTheConfiguredBaseBackoff()
+    {
+        using var response = new HttpResponseMessage(HttpStatusCode.ServiceUnavailable);
+
+        var delay = QaseHttpPolicies.ComputeDelay(3, TimeSpan.FromMilliseconds(500), response);
+
+        delay.Should().Be(TimeSpan.FromSeconds(2));
+    }
+
+    [Fact]
+    public void ComputeDelay_ShouldFallBackToBackoffWhenThereIsNoResponse()
+    {
+        var delay = QaseHttpPolicies.ComputeDelay(2, TimeSpan.FromSeconds(1), null);
+
+        delay.Should().Be(TimeSpan.FromSeconds(2));
+    }
+
+    [Fact]
+    public void ComputeDelay_ShouldHonourRetryAfterDeltaSecondsOverTheComputedBackoff()
+    {
+        using var response = new HttpResponseMessage((HttpStatusCode)429);
+        response.Headers.RetryAfter = new RetryConditionHeaderValue(TimeSpan.FromSeconds(60));
+
+        // The computed backoff for the first attempt would be 1 second.
+        var delay = QaseHttpPolicies.ComputeDelay(1, TimeSpan.FromSeconds(1), response);
+
+        delay.Should().Be(TimeSpan.FromSeconds(60));
+    }
+
+    [Fact]
+    public void ComputeDelay_ShouldHonourRetryAfterAsHttpDate()
+    {
+        using var response = new HttpResponseMessage((HttpStatusCode)429);
+        response.Headers.Date = DateTimeOffset.UtcNow;
+        response.Headers.RetryAfter =
+            new RetryConditionHeaderValue(DateTimeOffset.UtcNow.AddSeconds(45));
+
+        var delay = QaseHttpPolicies.ComputeDelay(1, TimeSpan.FromSeconds(1), response);
+
+        delay.Should().BeCloseTo(TimeSpan.FromSeconds(45), TimeSpan.FromSeconds(2));
+    }
+
+    [Fact]
+    public void ComputeDelay_ShouldIgnoreRetryAfterDateAlreadyInThePast()
+    {
+        using var response = new HttpResponseMessage((HttpStatusCode)429);
+        response.Headers.RetryAfter =
+            new RetryConditionHeaderValue(DateTimeOffset.UtcNow.AddSeconds(-30));
+
+        var delay = QaseHttpPolicies.ComputeDelay(2, TimeSpan.FromSeconds(1), response);
+
+        delay.Should().Be(TimeSpan.FromSeconds(2));
+    }
+
+    [Fact]
+    public void ComputeDelay_ShouldUseRetryAfterEvenWhenItIsShorterThanTheBackoff()
+    {
+        using var response = new HttpResponseMessage((HttpStatusCode)429);
+        response.Headers.RetryAfter = new RetryConditionHeaderValue(TimeSpan.FromSeconds(2));
+
+        // The computed backoff for the fourth attempt would be 8 seconds.
+        var delay = QaseHttpPolicies.ComputeDelay(4, TimeSpan.FromSeconds(1), response);
+
+        delay.Should().Be(TimeSpan.FromSeconds(2));
+    }
+
+    private static readonly TimeSpan FastBackoff = TimeSpan.FromMilliseconds(1);
+
+    /// <summary>
+    /// Counts how many times the policy asked for the operation, and replays
+    /// the given responses in order (repeating the last one once exhausted).
+    /// </summary>
+    private sealed class ResponseSequence
+    {
+        private readonly HttpStatusCode[] _statuses;
+
+        public ResponseSequence(params HttpStatusCode[] statuses) => _statuses = statuses;
+
+        public int Attempts { get; private set; }
+
+        public Task<HttpResponseMessage> NextAsync()
+        {
+            var status = _statuses[Math.Min(Attempts, _statuses.Length - 1)];
+            Attempts++;
+            return Task.FromResult(new HttpResponseMessage(status));
+        }
+    }
+
+    [Theory]
+    [InlineData(HttpStatusCode.RequestTimeout)]
+    [InlineData((HttpStatusCode)429)]
+    [InlineData(HttpStatusCode.InternalServerError)]
+    [InlineData(HttpStatusCode.ServiceUnavailable)]
+    public async Task RetryPolicy_ShouldExhaustAllAttemptsOnRetryableStatuses(HttpStatusCode status)
+    {
+        var sequence = new ResponseSequence(status);
+        var policy = QaseHttpPolicies.CreateRetryPolicy(3, FastBackoff, NullLogger.Instance);
+
+        var response = await policy.ExecuteAsync(_ => sequence.NextAsync(), new Context());
+
+        // One initial attempt plus three retries.
+        sequence.Attempts.Should().Be(4);
+        response.StatusCode.Should().Be(status);
+    }
+
+    [Theory]
+    [InlineData(HttpStatusCode.BadRequest)]
+    [InlineData(HttpStatusCode.Unauthorized)]
+    [InlineData(HttpStatusCode.Forbidden)]
+    [InlineData(HttpStatusCode.NotFound)]
+    [InlineData(HttpStatusCode.RequestEntityTooLarge)]
+    [InlineData((HttpStatusCode)422)]
+    [InlineData((HttpStatusCode)507)]
+    public async Task RetryPolicy_ShouldNotRetryPermanentFailures(HttpStatusCode status)
+    {
+        var sequence = new ResponseSequence(status);
+        var policy = QaseHttpPolicies.CreateRetryPolicy(3, FastBackoff, NullLogger.Instance);
+
+        await policy.ExecuteAsync(_ => sequence.NextAsync(), new Context());
+
+        sequence.Attempts.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task RetryPolicy_ShouldStopAsSoonAsAnAttemptSucceeds()
+    {
+        var sequence = new ResponseSequence(
+            (HttpStatusCode)429, HttpStatusCode.ServiceUnavailable, HttpStatusCode.OK);
+        var policy = QaseHttpPolicies.CreateRetryPolicy(5, FastBackoff, NullLogger.Instance);
+
+        var response = await policy.ExecuteAsync(_ => sequence.NextAsync(), new Context());
+
+        sequence.Attempts.Should().Be(3);
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task RetryPolicy_ShouldRetryTransportFailures()
+    {
+        var attempts = 0;
+        var policy = QaseHttpPolicies.CreateRetryPolicy(2, FastBackoff, NullLogger.Instance);
+
+        var act = async () => await policy.ExecuteAsync(_ =>
+        {
+            attempts++;
+            throw new HttpRequestException("connection reset");
+        }, new Context());
+
+        await act.Should().ThrowAsync<HttpRequestException>();
+        attempts.Should().Be(3);
+    }
+
+    [Fact]
+    public async Task RetryPolicy_ShouldWaitForRetryAfterInsteadOfTheComputedBackoff()
+    {
+        var attempts = 0;
+        var policy = QaseHttpPolicies.CreateRetryPolicy(1, FastBackoff, NullLogger.Instance);
+        var stopwatch = Stopwatch.StartNew();
+
+        await policy.ExecuteAsync(_ =>
+        {
+            attempts++;
+            var response = new HttpResponseMessage((HttpStatusCode)429);
+            response.Headers.RetryAfter = new RetryConditionHeaderValue(TimeSpan.FromSeconds(1));
+            return Task.FromResult(response);
+        }, new Context());
+
+        stopwatch.Stop();
+        attempts.Should().Be(2);
+        // The 1 ms computed backoff would have made this return almost instantly.
+        stopwatch.Elapsed.Should().BeGreaterThan(TimeSpan.FromMilliseconds(900));
+    }
+
+    [Fact]
+    public async Task TimeoutPolicy_ShouldAbortARequestThatStallsPastTheTimeout()
+    {
+        var policy = QaseHttpPolicies.CreateTimeoutPolicy(TimeSpan.FromMilliseconds(100));
+
+        var act = async () => await policy.ExecuteAsync(async token =>
+        {
+            await Task.Delay(TimeSpan.FromSeconds(10), token);
+            return new HttpResponseMessage(HttpStatusCode.OK);
+        }, CancellationToken.None);
+
+        await act.Should().ThrowAsync<TimeoutRejectedException>();
+    }
+
+    [Fact]
+    public async Task TimeoutPolicy_ShouldLetAFastRequestThrough()
+    {
+        var policy = QaseHttpPolicies.CreateTimeoutPolicy(TimeSpan.FromSeconds(5));
+
+        var response = await policy.ExecuteAsync(
+            _ => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)), CancellationToken.None);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task RetryPolicy_ShouldRetryAttemptsKilledByTheTimeoutPolicy()
+    {
+        var attempts = 0;
+        var retry = QaseHttpPolicies.CreateRetryPolicy(2, FastBackoff, NullLogger.Instance);
+        var timeout = QaseHttpPolicies.CreateTimeoutPolicy(TimeSpan.FromMilliseconds(100));
+
+        // Retry wraps timeout, exactly as the handler chain orders them.
+        var act = async () => await retry.WrapAsync(timeout).ExecuteAsync(async token =>
+        {
+            attempts++;
+            await Task.Delay(TimeSpan.FromSeconds(10), token);
+            return new HttpResponseMessage(HttpStatusCode.OK);
+        }, CancellationToken.None);
+
+        await act.Should().ThrowAsync<TimeoutRejectedException>();
+        attempts.Should().Be(3);
+    }
+
+    [Theory]
+    [InlineData(45, 45)]
+    [InlineData(1, 1)]
+    [InlineData(0, 30)]
+    [InlineData(-5, 30)]
+    public void ResolveTimeout_ShouldFallBackToTheDefaultForNonPositiveValues(int configured, int expected)
+    {
+        QaseHttpPolicies.ResolveTimeout(configured).Should().Be(TimeSpan.FromSeconds(expected));
+    }
+
+    [Theory]
+    [InlineData(3, 3)]
+    [InlineData(0, 0)]
+    [InlineData(-2, 0)]
+    public void ResolveRetries_ShouldClampNegativeValuesToZero(int configured, int expected)
+    {
+        QaseHttpPolicies.ResolveRetries(configured).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData(2.5, 2.5)]
+    [InlineData(0.0, 1.0)]
+    [InlineData(-1.0, 1.0)]
+    public void ResolveBackoff_ShouldFallBackToTheDefaultForNonPositiveValues(double configured, double expected)
+    {
+        QaseHttpPolicies.ResolveBackoff(configured).Should().Be(TimeSpan.FromSeconds(expected));
+    }
+
+    [Theory]
+    [InlineData(20)]
+    [InlineData(40)]
+    [InlineData(64)]
+    public void ComputeDelay_ShouldCapTheBackoffInsteadOfOverflowing(int attempt)
+    {
+        using var response = new HttpResponseMessage(HttpStatusCode.ServiceUnavailable);
+
+        var delay = QaseHttpPolicies.ComputeDelay(attempt, TimeSpan.FromSeconds(1), response);
+
+        delay.Should().BePositive();
+        delay.Should().BeLessThanOrEqualTo(TimeSpan.FromMinutes(10));
+    }
+}

--- a/Qase.Csharp.Commons.Tests/TestopsReporterFailedUploadTests.cs
+++ b/Qase.Csharp.Commons.Tests/TestopsReporterFailedUploadTests.cs
@@ -1,0 +1,166 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Qase.Csharp.Commons.Clients;
+using Qase.Csharp.Commons.Config;
+using Qase.Csharp.Commons.Core;
+using Qase.Csharp.Commons.Models.Domain;
+using Qase.Csharp.Commons.Reporters;
+
+namespace Qase.Csharp.Commons.Tests;
+
+/// <summary>
+/// What happens to the buffer and to the test run when an upload cannot be recovered.
+/// </summary>
+public class TestopsReporterFailedUploadTests
+{
+    private readonly Mock<IClient> _client = new();
+    private readonly QaseConfig _config;
+    private readonly TestopsReporter _reporter;
+
+    public TestopsReporterFailedUploadTests()
+    {
+        _config = new QaseConfig
+        {
+            TestOps = new TestOpsConfig
+            {
+                Project = "TEST",
+                Api = new ApiConfig { Host = "qase.io" },
+                Batch = new BatchConfig { Size = 10 },
+                Run = new RunConfig { Id = 42 }
+            }
+        };
+        _reporter = new TestopsReporter(NullLogger<TestopsReporter>.Instance, _config, _client.Object);
+    }
+
+    private static TestResult Result(string title) => new()
+    {
+        Title = title,
+        Execution = new TestResultExecution { Status = TestResultStatus.Passed }
+    };
+
+    private async Task BufferAsync(int count)
+    {
+        await _reporter.startTestRun();
+        for (var i = 0; i < count; i++)
+        {
+            await _reporter.addResult(Result($"test {i}"));
+        }
+    }
+
+    [Fact]
+    public async Task UploadResults_ShouldKeepTheBufferWhenTheUploadThrows()
+    {
+        _client.Setup(c => c.UploadResultsAsync(It.IsAny<long>(), It.IsAny<List<TestResult>>()))
+            .ThrowsAsync(new QaseException("retries exhausted"));
+        await BufferAsync(3);
+
+        var act = async () => await _reporter.uploadResults();
+
+        await act.Should().ThrowAsync<QaseException>();
+        var kept = await _reporter.getResults();
+        kept.Should().HaveCount(3, "results that were never delivered must stay available to the fallback reporter");
+    }
+
+    [Fact]
+    public async Task AddResult_ShouldKeepTheBufferWhenTheBatchUploadThrows()
+    {
+        _client.Setup(c => c.UploadResultsAsync(It.IsAny<long>(), It.IsAny<List<TestResult>>()))
+            .ThrowsAsync(new QaseException("retries exhausted"));
+        await _reporter.startTestRun();
+
+        // The tenth result trips the configured batch size of 10.
+        var act = async () =>
+        {
+            for (var i = 0; i < 10; i++)
+            {
+                await _reporter.addResult(Result($"test {i}"));
+            }
+        };
+
+        await act.Should().ThrowAsync<QaseException>();
+        (await _reporter.getResults()).Should().HaveCount(10);
+    }
+
+    [Fact]
+    public async Task UploadResults_ShouldClearTheBufferOnSuccess()
+    {
+        await BufferAsync(3);
+
+        await _reporter.uploadResults();
+
+        (await _reporter.getResults()).Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task CompleteTestRun_ShouldNotCompleteARunThatLostResults()
+    {
+        _client.Setup(c => c.UploadResultsAsync(It.IsAny<long>(), It.IsAny<List<TestResult>>()))
+            .ThrowsAsync(new QaseException("retries exhausted"));
+        await BufferAsync(3);
+        await Assert.ThrowsAsync<QaseException>(() => _reporter.uploadResults());
+
+        await _reporter.completeTestRun();
+
+        _client.Verify(c => c.CompleteTestRunAsync(It.IsAny<long>()), Times.Never,
+            "a completed run over partial data looks trustworthy and is not");
+    }
+
+    [Fact]
+    public async Task CompleteTestRun_ShouldCompleteARunThatLostNothing()
+    {
+        await BufferAsync(3);
+        await _reporter.uploadResults();
+
+        await _reporter.completeTestRun();
+
+        _client.Verify(c => c.CompleteTestRunAsync(42), Times.Once);
+    }
+
+    [Fact]
+    public async Task UploadResults_ShouldReportHowManyResultsWereLost()
+    {
+        var logger = new Mock<ILogger<TestopsReporter>>();
+        var reporter = new TestopsReporter(logger.Object, _config, _client.Object);
+        _client.Setup(c => c.UploadResultsAsync(It.IsAny<long>(), It.IsAny<List<TestResult>>()))
+            .ThrowsAsync(new QaseException("retries exhausted"));
+        await reporter.startTestRun();
+        for (var i = 0; i < 3; i++)
+        {
+            await reporter.addResult(Result($"test {i}"));
+        }
+
+        await Assert.ThrowsAsync<QaseException>(() => reporter.uploadResults());
+
+        logger.Verify(l => l.Log(
+            LogLevel.Error,
+            It.IsAny<EventId>(),
+            It.Is<It.IsAnyType>((v, _) => v.ToString()!.Contains("3")),
+            It.IsAny<Exception>(),
+            It.IsAny<Func<It.IsAnyType, Exception?, string>>()), Times.AtLeastOnce);
+    }
+
+    [Fact]
+    public async Task UploadResults_ShouldOnlyDropChunksTheServerAccepted()
+    {
+        _config.TestOps.Batch.Size = 2;
+        var sent = new List<List<TestResult>>();
+        _client.Setup(c => c.UploadResultsAsync(It.IsAny<long>(), It.IsAny<List<TestResult>>()))
+            .Returns((long _, List<TestResult> batch) =>
+            {
+                sent.Add(batch.ToList());
+                // The first chunk lands, the second one does not.
+                return sent.Count == 1 ? Task.CompletedTask : Task.FromException(new QaseException("boom"));
+            });
+        await _reporter.startTestRun();
+        await _reporter.setResults(Enumerable.Range(0, 6).Select(i => Result($"test {i}")).ToList());
+
+        await Assert.ThrowsAsync<QaseException>(() => _reporter.uploadResults());
+
+        var kept = await _reporter.getResults();
+        kept.Should().HaveCount(4, "the two results already delivered must not be handed to the fallback again");
+        kept.Select(r => r.Title).Should().Equal("test 2", "test 3", "test 4", "test 5");
+    }
+}

--- a/Qase.Csharp.Commons/Qase.Csharp.Commons.csproj
+++ b/Qase.Csharp.Commons/Qase.Csharp.Commons.csproj
@@ -32,6 +32,7 @@
     <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
     <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
     <PackageReference Include="AspectInjector" Version="2.8.2" />
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="5.0.1" />
   </ItemGroup>
 
 </Project>

--- a/Qase.Csharp.Commons/README.md
+++ b/Qase.Csharp.Commons/README.md
@@ -42,6 +42,9 @@ All configuration options are listed in the table below:
 | Token for [API access](https://developers.qase.io/#authentication)                                                         | `testops.api.token`        | `QASE_TESTOPS_API_TOKEN`        | `QASE_TESTOPS_API_TOKEN`        | undefined                               | Yes      | Any string                 |
 | Qase API host. For enterprise users, specify address: `example.qase.io`                                           | `testops.api.host`         | `QASE_TESTOPS_API_HOST`         | `QASE_TESTOPS_API_HOST`         | `qase.io`                               | No       | Any string                 |
 | Qase enterprise environment                                                                                                | `testops.api.enterprise`   | `QASE_TESTOPS_API_ENTERPRISE`   | `QASE_TESTOPS_API_ENTERPRISE`   | `False`                                 | No       | `True`, `False`            |
+| Timeout of a single API request, in seconds                                                                                | `testops.api.timeout`      | `QASE_TESTOPS_API_TIMEOUT`      | `QASE_TESTOPS_API_TIMEOUT`      | `30`                                    | No       | Any positive integer       |
+| Number of retries for a failed results upload                                                                              | `testops.api.retries`      | `QASE_TESTOPS_API_RETRIES`      | `QASE_TESTOPS_API_RETRIES`      | `3`                                     | No       | `0` or any positive integer |
+| Base delay of the exponential retry backoff, in seconds                                                                    | `testops.api.retryBackoff` | `QASE_TESTOPS_API_RETRY_BACKOFF` | `QASE_TESTOPS_API_RETRY_BACKOFF` | `1`                                     | No       | Any positive number        |
 | Code of your project, which you can take from the URL: `https://app.qase.io/project/DEMOTR` - `DEMOTR` is the project code | `testops.project`          | `QASE_TESTOPS_PROJECT`          | `QASE_TESTOPS_PROJECT`          | undefined                               | Yes      | Any string                 |
 | Qase test run ID                                                                                                           | `testops.run.id`           | `QASE_TESTOPS_RUN_ID`           | `QASE_TESTOPS_RUN_ID`           | undefined                               | No       | Any integer                |
 | Qase test run title                                                                                                        | `testops.run.title`        | `QASE_TESTOPS_RUN_TITLE`        | `QASE_TESTOPS_RUN_TITLE`        | `Automated run <Current date and time>` | No       | Any string                 |
@@ -58,6 +61,27 @@ All configuration options are listed in the table below:
 | Filter results by status                      | `testops.statusFilter`                | `QASE_TESTOPS_STATUS_FILTER`     | `QASE_TESTOPS_STATUS_FILTER`     | None, don't filter any results          | No       | Comma-separated list of statuses |
 | Whether to show public report link after test run completion              | `testops.showPublicReportLink`                | `QASE_TESTOPS_SHOW_PUBLIC_REPORT_LINK`     | `QASE_TESTOPS_SHOW_PUBLIC_REPORT_LINK`     | `False`                                 | No       | `True`, `False`            |
 | Status mapping for test results               | `statusMapping`                       | `QASE_STATUS_MAPPING`            | `QASE_STATUS_MAPPING`            | None, don't map any statuses            | No       | JSON object or comma-separated key=value pairs |
+
+### Retries and timeouts
+
+Uploading test results is the one call worth retrying, and it is safe to retry
+because every result carries an id that Qase uses to deduplicate a batch it has
+already accepted.
+
+A results upload is retried on a transport failure and on HTTP 408, 429 and 5xx,
+with an exponential backoff of `retryBackoff × 2^(attempt-1)`. It is not retried
+on 400, 401, 403, 404, 413, 422 or 507 — those fail identically on a second
+attempt. When a 429 carries a `Retry-After` header, that value is used instead of
+the computed backoff; Qase sends roughly 60 seconds, which a short backoff ladder
+would not survive. `timeout` applies to each attempt, not to the chain as a whole.
+
+Creating and completing a test run is not retried: those calls carry no
+idempotency key, so a replay could create a second run. They still honour
+`timeout`.
+
+If a batch cannot be uploaded even after the retries, the reporter logs an error
+naming how many results were lost and leaves the test run **open**. A completed
+run over partial data looks trustworthy and is not.
 
 ### Example `qase.config.json` config
 
@@ -83,7 +107,10 @@ All configuration options are listed in the table below:
   "testops": {
     "api": {
       "token": "<token>",
-      "host": "qase.io"
+      "host": "qase.io",
+      "timeout": 30,
+      "retries": 3,
+      "retryBackoff": 1
     },
     "run": {
       "title": "Regress run",

--- a/Qase.Csharp.Commons/ServiceCollectionExtensions.cs
+++ b/Qase.Csharp.Commons/ServiceCollectionExtensions.cs
@@ -105,6 +105,10 @@ namespace Qase.Csharp.Commons
                             builder.ConfigureHttpClient(httpClient =>
                             {
                                 httpClient.DefaultRequestHeaders.UserAgent.ParseAdd(userAgent);
+                                // No retry here: POST /run carries no idempotency key, so a
+                                // replay of a request whose response was lost would create a
+                                // second test run.
+                                httpClient.Timeout = QaseHttpPolicies.ResolveTimeout(config.TestOps.Api.Timeout);
                             });
                         });
                 });
@@ -152,6 +156,11 @@ namespace Qase.Csharp.Commons
                         },
                         builder =>
                         {
+                            // Results carry result.Id as an idempotency key, so replaying a
+                            // batch the server already accepted is deduplicated rather than
+                            // duplicated. That is what makes retrying safe here.
+                            builder.AddQaseResultsPolicies(config.TestOps.Api, logger);
+
                             // Add headers to all HTTP requests
                             builder.ConfigureHttpClient(httpClient =>
                             {

--- a/Qase.Csharp.Commons/clients/QaseHttpPolicies.cs
+++ b/Qase.Csharp.Commons/clients/QaseHttpPolicies.cs
@@ -1,0 +1,201 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Polly;
+using Polly.Timeout;
+using Qase.Csharp.Commons.Config;
+
+namespace Qase.Csharp.Commons.Clients
+{
+    /// <summary>
+    /// Builds the HTTP resilience policies used by the Qase API clients.
+    /// </summary>
+    internal static class QaseHttpPolicies
+    {
+        private static readonly TimeSpan DefaultTimeout = TimeSpan.FromSeconds(30);
+        private static readonly TimeSpan DefaultBackoff = TimeSpan.FromSeconds(1);
+
+        // Doubling without a ceiling reaches days of waiting — and eventually
+        // overflows — if someone configures a large retry count.
+        private static readonly TimeSpan MaxComputedBackoff = TimeSpan.FromMinutes(10);
+
+        /// <summary>
+        /// Applies the retry and timeout policies used for the test results upload path.
+        /// </summary>
+        /// <param name="builder">The HTTP client builder to configure</param>
+        /// <param name="api">The API connection settings</param>
+        /// <param name="logger">The logger used to report each retry</param>
+        /// <returns>The builder, for chaining</returns>
+        internal static IHttpClientBuilder AddQaseResultsPolicies(
+            this IHttpClientBuilder builder, ApiConfig api, ILogger logger)
+        {
+            // HttpClient's own timeout spans the entire handler chain. Left at its
+            // 100 second default it would cut short a retry ladder that honours a
+            // 60 second Retry-After, so the per-attempt limit is Polly's instead.
+            builder.ConfigureHttpClient(client => client.Timeout = Timeout.InfiniteTimeSpan);
+
+            // Order matters: the first handler added is the outermost one, so retry
+            // wraps timeout and each attempt gets its own deadline.
+            builder.AddPolicyHandler(CreateRetryPolicy(
+                ResolveRetries(api.Retries), ResolveBackoff(api.RetryBackoff), logger));
+            builder.AddPolicyHandler(CreateTimeoutPolicy(ResolveTimeout(api.Timeout)));
+
+            return builder;
+        }
+
+        /// <summary>
+        /// Turns the configured timeout into a usable value.
+        /// </summary>
+        /// <param name="seconds">The configured timeout in seconds</param>
+        /// <returns>The timeout to apply</returns>
+        internal static TimeSpan ResolveTimeout(int seconds)
+        {
+            return seconds > 0 ? TimeSpan.FromSeconds(seconds) : DefaultTimeout;
+        }
+
+        /// <summary>
+        /// Turns the configured retry count into a usable value.
+        /// </summary>
+        /// <param name="retries">The configured number of retries</param>
+        /// <returns>The retry count to apply</returns>
+        internal static int ResolveRetries(int retries)
+        {
+            return retries > 0 ? retries : 0;
+        }
+
+        /// <summary>
+        /// Turns the configured backoff into a usable value.
+        /// </summary>
+        /// <param name="seconds">The configured base backoff in seconds</param>
+        /// <returns>The base backoff to apply</returns>
+        internal static TimeSpan ResolveBackoff(double seconds)
+        {
+            return seconds > 0 ? TimeSpan.FromSeconds(seconds) : DefaultBackoff;
+        }
+
+        /// <summary>
+        /// Builds the retry policy used for the test results upload path.
+        /// </summary>
+        /// <param name="retries">How many times to retry after the first attempt</param>
+        /// <param name="baseBackoff">The base delay the exponential backoff grows from</param>
+        /// <param name="logger">The logger used to report each retry</param>
+        /// <returns>The retry policy</returns>
+        internal static IAsyncPolicy<HttpResponseMessage> CreateRetryPolicy(
+            int retries, TimeSpan baseBackoff, ILogger logger)
+        {
+            return Policy
+                .HandleResult<HttpResponseMessage>(response => IsRetryableStatus(response.StatusCode))
+                .Or<HttpRequestException>()
+                .Or<TimeoutRejectedException>()
+                .WaitAndRetryAsync(
+                    retries,
+                    (attempt, outcome, _) => ComputeDelay(attempt, baseBackoff, outcome.Result),
+                    (outcome, delay, attempt, _) =>
+                    {
+                        if (outcome.Exception != null)
+                        {
+                            logger.LogWarning(
+                                "Qase API request failed ({Error}); retry {Attempt} of {Retries} in {Delay}",
+                                outcome.Exception.Message, attempt, retries, delay);
+                        }
+                        else
+                        {
+                            logger.LogWarning(
+                                "Qase API responded {StatusCode}; retry {Attempt} of {Retries} in {Delay}",
+                                (int)outcome.Result.StatusCode, attempt, retries, delay);
+                        }
+
+                        return Task.CompletedTask;
+                    });
+        }
+
+        /// <summary>
+        /// Builds the per-attempt timeout policy.
+        /// </summary>
+        /// <param name="timeout">How long a single attempt may take</param>
+        /// <returns>The timeout policy</returns>
+        internal static IAsyncPolicy<HttpResponseMessage> CreateTimeoutPolicy(TimeSpan timeout)
+        {
+            return Policy.TimeoutAsync<HttpResponseMessage>(timeout);
+        }
+
+        /// <summary>
+        /// Determines whether a response status is worth retrying.
+        /// </summary>
+        /// <param name="statusCode">The status code returned by the server</param>
+        /// <returns>True when a retry may succeed, false when the failure is permanent</returns>
+        internal static bool IsRetryableStatus(HttpStatusCode statusCode)
+        {
+            var code = (int)statusCode;
+
+            // 507 is a 5xx, but the server is telling us it has no room for this
+            // payload. A second identical batch fails the same way.
+            if (code == 507)
+            {
+                return false;
+            }
+
+            return code == 408 || code == 429 || code >= 500;
+        }
+
+        /// <summary>
+        /// Computes how long to wait before the next attempt.
+        /// </summary>
+        /// <param name="attempt">The 1-based number of the attempt that just failed</param>
+        /// <param name="baseBackoff">The base delay the exponential backoff grows from</param>
+        /// <param name="response">The response that triggered the retry, if there was one</param>
+        /// <returns>The delay before the next attempt</returns>
+        internal static TimeSpan ComputeDelay(int attempt, TimeSpan baseBackoff, HttpResponseMessage? response)
+        {
+            var retryAfter = ReadRetryAfter(response);
+            if (retryAfter.HasValue)
+            {
+                return retryAfter.Value;
+            }
+
+            var multiplier = Math.Pow(2, attempt - 1);
+            var ticks = baseBackoff.Ticks * multiplier;
+
+            return ticks >= MaxComputedBackoff.Ticks
+                ? MaxComputedBackoff
+                : TimeSpan.FromTicks((long)ticks);
+        }
+
+        /// <summary>
+        /// Reads the Retry-After header, in either of the two forms the spec allows.
+        /// </summary>
+        /// <param name="response">The response to read the header from</param>
+        /// <returns>The delay the server asked for, or null when it did not ask</returns>
+        private static TimeSpan? ReadRetryAfter(HttpResponseMessage? response)
+        {
+            var retryAfter = response?.Headers.RetryAfter;
+            if (retryAfter == null)
+            {
+                return null;
+            }
+
+            if (retryAfter.Delta.HasValue && retryAfter.Delta.Value > TimeSpan.Zero)
+            {
+                return retryAfter.Delta.Value;
+            }
+
+            if (retryAfter.Date.HasValue)
+            {
+                // Prefer the server's own clock when it sent one, so clock skew
+                // between us and Qase does not stretch or shrink the wait.
+                var now = response!.Headers.Date ?? DateTimeOffset.UtcNow;
+                var wait = retryAfter.Date.Value - now;
+                if (wait > TimeSpan.Zero)
+                {
+                    return wait;
+                }
+            }
+
+            return null;
+        }
+    }
+}

--- a/Qase.Csharp.Commons/config/ApiConfig.cs
+++ b/Qase.Csharp.Commons/config/ApiConfig.cs
@@ -14,5 +14,20 @@ namespace Qase.Csharp.Commons.Config
         /// Gets or sets the API host
         /// </summary>
         public string? Host { get; set; } = "qase.io";
+
+        /// <summary>
+        /// Gets or sets the timeout of a single API request, in seconds
+        /// </summary>
+        public int Timeout { get; set; } = 30;
+
+        /// <summary>
+        /// Gets or sets how many times a failed results upload is retried
+        /// </summary>
+        public int Retries { get; set; } = 3;
+
+        /// <summary>
+        /// Gets or sets the base delay of the exponential retry backoff, in seconds
+        /// </summary>
+        public double RetryBackoff { get; set; } = 1;
     }
 }

--- a/Qase.Csharp.Commons/config/BatchConfig.cs
+++ b/Qase.Csharp.Commons/config/BatchConfig.cs
@@ -8,6 +8,6 @@ namespace Qase.Csharp.Commons.Config
         /// <summary>
         /// Gets or sets the batch size
         /// </summary>
-        public int Size { get; set; }
+        public int Size { get; set; } = 200;
     }
 } 

--- a/Qase.Csharp.Commons/config/ConfigFactory.cs
+++ b/Qase.Csharp.Commons/config/ConfigFactory.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text.Json;
@@ -112,6 +113,9 @@ namespace Qase.Csharp.Commons.Config
             qaseConfig.TestOps.Defect = GetBooleanEnv("QASE_TESTOPS_DEFECT", qaseConfig.TestOps.Defect);
             qaseConfig.TestOps.Api.Token = GetEnv("QASE_TESTOPS_API_TOKEN", qaseConfig.TestOps.Api.Token);
             qaseConfig.TestOps.Api.Host = GetEnv("QASE_TESTOPS_API_HOST", qaseConfig.TestOps.Api.Host);
+            qaseConfig.TestOps.Api.Timeout = GetIntEnvOrDefault("QASE_TESTOPS_API_TIMEOUT", qaseConfig.TestOps.Api.Timeout);
+            qaseConfig.TestOps.Api.Retries = GetIntEnvOrDefault("QASE_TESTOPS_API_RETRIES", qaseConfig.TestOps.Api.Retries);
+            qaseConfig.TestOps.Api.RetryBackoff = GetDoubleEnvOrDefault("QASE_TESTOPS_API_RETRY_BACKOFF", qaseConfig.TestOps.Api.RetryBackoff);
             qaseConfig.TestOps.Run.Title = GetEnv("QASE_TESTOPS_RUN_TITLE", qaseConfig.TestOps.Run.Title);
             qaseConfig.TestOps.Run.Description = GetEnv("QASE_TESTOPS_RUN_DESCRIPTION", qaseConfig.TestOps.Run.Description);
             qaseConfig.TestOps.Run.Id = GetLongEnv("QASE_TESTOPS_RUN_ID", qaseConfig.TestOps.Run.Id);
@@ -249,6 +253,40 @@ namespace Qase.Csharp.Commons.Config
         }
 
         /// <summary>
+        /// Gets an integer environment variable, keeping the default when the value is not a number
+        /// </summary>
+        /// <param name="key">Environment variable name</param>
+        /// <param name="defaultValue">Default value</param>
+        /// <returns>Environment variable value as integer or default</returns>
+        private static int GetIntEnvOrDefault(string key, int defaultValue)
+        {
+            var value = Environment.GetEnvironmentVariable(key);
+            if (value != null && int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var result))
+            {
+                return result;
+            }
+
+            return defaultValue;
+        }
+
+        /// <summary>
+        /// Gets a double environment variable, keeping the default when the value is not a number
+        /// </summary>
+        /// <param name="key">Environment variable name</param>
+        /// <param name="defaultValue">Default value</param>
+        /// <returns>Environment variable value as double or default</returns>
+        private static double GetDoubleEnvOrDefault(string key, double defaultValue)
+        {
+            var value = Environment.GetEnvironmentVariable(key);
+            if (value != null && double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out var result))
+            {
+                return result;
+            }
+
+            return defaultValue;
+        }
+
+        /// <summary>
         /// Gets a long environment variable or returns default value
         /// </summary>
         /// <param name="key">Environment variable name</param>
@@ -375,6 +413,24 @@ namespace Qase.Csharp.Commons.Config
                         hostElement.ValueKind == JsonValueKind.String)
                     {
                         qaseConfig.TestOps.Api.Host = hostElement.GetString();
+                    }
+
+                    if (apiElement.TryGetProperty("timeout", out var timeoutElement) &&
+                        timeoutElement.ValueKind == JsonValueKind.Number)
+                    {
+                        qaseConfig.TestOps.Api.Timeout = timeoutElement.GetInt32();
+                    }
+
+                    if (apiElement.TryGetProperty("retries", out var retriesElement) &&
+                        retriesElement.ValueKind == JsonValueKind.Number)
+                    {
+                        qaseConfig.TestOps.Api.Retries = retriesElement.GetInt32();
+                    }
+
+                    if (apiElement.TryGetProperty("retryBackoff", out var retryBackoffElement) &&
+                        retryBackoffElement.ValueKind == JsonValueKind.Number)
+                    {
+                        qaseConfig.TestOps.Api.RetryBackoff = retryBackoffElement.GetDouble();
                     }
                 }
 

--- a/Qase.Csharp.Commons/reporters/TestopsReporter.cs
+++ b/Qase.Csharp.Commons/reporters/TestopsReporter.cs
@@ -21,6 +21,7 @@ namespace Qase.Csharp.Commons.Reporters
         private readonly IClient _client;
         private long _testRunId;
         private readonly List<TestResult> _results;
+        private bool _uploadFailed;
 
         /// <summary>
         /// Initializes a new instance of the TestopsReporter class
@@ -56,6 +57,16 @@ namespace Qase.Csharp.Commons.Reporters
         /// <inheritdoc />
         public async Task completeTestRun()
         {
+            if (_uploadFailed)
+            {
+                // A completed run over partial data looks trustworthy and is not.
+                // Leaving it open is the honest signal that something is missing.
+                _logger.LogError(
+                    "Test run {RunId} left incomplete: {Count} test results could not be uploaded to Qase",
+                    _testRunId, _results.Count);
+                return;
+            }
+
             if (!_config.TestOps.Run.Complete)
             {
                 _logger.LogInformation("Test run {RunId} completion skipped (run.complete=false)", _testRunId);
@@ -120,36 +131,46 @@ namespace Qase.Csharp.Commons.Reporters
 
             if (_results.Count >= _config.TestOps.Batch.Size)
             {
-                await _client.UploadResultsAsync(_testRunId, _results);
-                _results.Clear();
+                await UploadBufferedResultsAsync();
             }
         }
 
         /// <inheritdoc />
-        public async Task uploadResults()
+        public Task uploadResults()
+        {
+            return UploadBufferedResultsAsync();
+        }
+
+        /// <summary>
+        /// Sends the buffered results in batches, dropping each batch from the
+        /// buffer only once the server has accepted it. Whatever is left when an
+        /// upload fails is still available to the fallback reporter.
+        /// </summary>
+        private async Task UploadBufferedResultsAsync()
         {
             var batchSize = _config.TestOps.Batch.Size;
-            var totalResults = _results.Count;
 
-            if (totalResults == 0)
+            while (_results.Count > 0)
             {
-                return;
-            }
+                var count = batchSize > 0 ? Math.Min(batchSize, _results.Count) : _results.Count;
+                var batch = _results.GetRange(0, count);
 
-            if (totalResults <= batchSize)
-            {
-                await _client.UploadResultsAsync(_testRunId, _results);
-                _results.Clear();
-                return;
-            }
+                try
+                {
+                    await _client.UploadResultsAsync(_testRunId, batch);
+                }
+                catch (QaseException ex)
+                {
+                    _uploadFailed = true;
+                    _logger.LogError(
+                        ex,
+                        "Failed to upload {Count} test results to Qase after all retries; they are lost from this run",
+                        _results.Count);
+                    throw;
+                }
 
-            for (var index = 0; index < totalResults; index += batchSize)
-            {
-                var end = Math.Min(index + batchSize, totalResults);
-                await _client.UploadResultsAsync(_testRunId, _results.GetRange(index, end - index));
+                _results.RemoveRange(0, count);
             }
-
-            _results.Clear();
         }
 
         /// <inheritdoc />

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## qase-csharp 1.1.26
+
+- Added retries for the test results upload, covering transport failures and HTTP 408, 429 and 5xx, with an exponential backoff that honours the `Retry-After` header
+- Added a configurable request timeout, defaulting to 30 seconds
+- Added the `testops.api.timeout`, `testops.api.retries` and `testops.api.retryBackoff` options, with `QASE_TESTOPS_API_TIMEOUT`, `QASE_TESTOPS_API_RETRIES` and `QASE_TESTOPS_API_RETRY_BACKOFF` overrides
+- A test run is now left open when a batch of results cannot be uploaded, and the number of lost results is reported
+
 ## qase-csharp 1.1.25
 
 - Updated API clients to the latest specification

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@
 - Added a configurable request timeout, defaulting to 30 seconds
 - Added the `testops.api.timeout`, `testops.api.retries` and `testops.api.retryBackoff` options, with `QASE_TESTOPS_API_TIMEOUT`, `QASE_TESTOPS_API_RETRIES` and `QASE_TESTOPS_API_RETRY_BACKOFF` overrides
 - A test run is now left open when a batch of results cannot be uploaded, and the number of lost results is reported
+- Fixed the default batch size, which was `0` instead of the documented `200` and made every result its own request
 
 ## qase-csharp 1.1.25
 


### PR DESCRIPTION
A results batch that failed to upload was lost silently, and a connection that
stalled rather than failed hung the test session at teardown until CI killed the
job. `AddRetryPolicy` existed in both generated API client projects but was never
called from anywhere, and nothing set a request timeout.

## Changes

**Retries.** New `QaseHttpPolicies` in `Qase.Csharp.Commons`, wired into the v2
results client. Retries cover transport failures and HTTP 408, 429 and 5xx, with
an exponential backoff of `retryBackoff × 2^(n-1)` capped at ten minutes. 400,
401, 403, 404, 413, 422 and 507 are never retried — they fail identically on a
second attempt. A `Retry-After` header, in either delta-seconds or HTTP-date
form, overrides the computed backoff; Qase sends roughly 60 seconds, which a
short ladder does not survive.

Retrying is safe here because every result already carries `result.Id` as an
idempotency key, so the server deduplicates a batch it has already accepted.

The v1 client deliberately gets no retry: `POST /run` carries no idempotency key,
so replaying a request whose response was lost would create a second test run.

**Timeout.** Configurable, defaulting to 30 seconds, applied to both v1 and v2.
On v2 it is a per-attempt Polly timeout and `HttpClient.Timeout` is opened up,
because its 100 second default spans the whole handler chain and would cut short
a retry ladder honouring a 60 second `Retry-After`.

**Unrecoverable batches.** When retries are exhausted the reporter logs an error
naming how many results were lost and leaves the test run open — a completed run
over partial data looks trustworthy and is not. The exception still propagates,
so the existing fallback reporter continues to rescue undelivered results to
disk.

**Buffer handling.** The multi-batch path now drops each chunk from the buffer
only once the server has accepted it. Previously it cleared the whole list at the
end of the loop, so a middle chunk failing left already-delivered results in the
buffer and handed them to the fallback reporter a second time. Not a data-loss
bug given the idempotency key, but the buffer state was wrong.

## Configuration

| Option | JSON | Env | Default |
|---|---|---|---|
| Request timeout, seconds | `testops.api.timeout` | `QASE_TESTOPS_API_TIMEOUT` | `30` |
| Retries | `testops.api.retries` | `QASE_TESTOPS_API_RETRIES` | `3` |
| Backoff base, seconds | `testops.api.retryBackoff` | `QASE_TESTOPS_API_RETRY_BACKOFF` | `1` |

## Tests

`dotnet test qase-csharp.sln` — 670 passing, 0 failures (Commons: 461 → 535).

Retryable and permanent statuses are covered at three levels: the predicate, the
Polly policy, and a real `HttpClient` pipeline. Also covered: `Retry-After`
overriding the backoff both as a value and as an actual wait, the POST body
surviving re-sends, an attempt killed by the timeout being retried, and the
buffer staying intact when an upload throws.

## Notes

- The unused `AddRetryPolicy` in the generated V1/V2 client projects is left as
  is. Its conditions did not match what is needed — no 429, no backoff, and 507
  retried as a 5xx — and editing it would be overwritten by the next
  regeneration from OpenAPI. It is now dead code and should be dropped from the
  generator.
- Policies attach to every client of their API version, since
  `AddApiHttpClients` applies the builder action to all of them. For v2 that also
  covers the read-only `ICustomFieldsApi`, which is harmless.
- Also fixed here: `BatchConfig.Size` had no initializer, so it defaulted to `0`
  while the README documents `200`. With `_results.Count >= Batch.Size` always
  true, an unconfigured reporter sent every result as its own request.
